### PR TITLE
CT: No code is treated as STOP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,6 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20240916105249-e7951db0c00b
+replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20250110103937-67c3da2574d3 // TODO: update once merged
 
 replace github.com/ethereum/evmc/v11 => ./third_party/evmc

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,6 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20250110103937-67c3da2574d3 // TODO: update once merged
+replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20250114122522-53aa5869fe65
 
 replace github.com/ethereum/evmc/v11 => ./third_party/evmc

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20250110103937-67c3da2574d3 h1:PaWP/dRNgjUNtxQODpUAczuAS30eGah/EEiQHj4Zsm0=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20250110103937-67c3da2574d3/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20250114122522-53aa5869fe65 h1:Nq56dHxco0YG8TvS7SE3fQlNRfG57Y2eebjv/FAqFog=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20250114122522-53aa5869fe65/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20240916105249-e7951db0c00b h1:MlQdAOrXxnPAhJ2lqtomnj4LYeA5d35bxH0+hCRBAvA=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20240916105249-e7951db0c00b/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20250110103937-67c3da2574d3 h1:PaWP/dRNgjUNtxQODpUAczuAS30eGah/EEiQHj4Zsm0=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20250110103937-67c3da2574d3/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -471,12 +471,6 @@ func (g *StateGenerator) generateWith(rnd *rand.Rand, assignment Assignment) (*s
 	// Generate return data of last call
 	resultLastCallReturnData := RandomBytes(rnd, st.MaxDataSize)
 
-	// Generate return data for terminal states.
-	var resultReturnData Bytes
-	if resultStatus == st.Stopped || resultStatus == st.Reverted {
-		resultReturnData = RandomBytes(rnd, st.MaxDataSize)
-	}
-
 	// Invoke SelfDestructedGenerator
 	resultHasSelfdestructed, err := g.hasSelfDestructedGen.Generate(rnd)
 	if err != nil {
@@ -534,6 +528,7 @@ func (g *StateGenerator) generateWith(rnd *rand.Rand, assignment Assignment) (*s
 
 	resultRevision := GetRevisionForBlock(resultBlockContext.BlockNumber)
 
+	// Return data is not set as it should only be set by RETURN/REVERT opcodes.
 	result := st.NewState(resultCode)
 	result.Status = resultStatus
 	result.Revision = resultRevision
@@ -552,7 +547,6 @@ func (g *StateGenerator) generateWith(rnd *rand.Rand, assignment Assignment) (*s
 	result.TransactionContext = resultTransactionContext
 	result.CallData = resultCallData
 	result.LastCallReturnData = resultLastCallReturnData
-	result.ReturnData = resultReturnData
 	result.HasSelfDestructed = resultHasSelfdestructed
 	result.RecentBlockHashes = resultRecentBlockHashes
 

--- a/regression_inputs/no_code_#5.json
+++ b/regression_inputs/no_code_#5.json
@@ -1,0 +1,16 @@
+{
+    "Status": "running",
+	"Revision": "Berlin",
+	"ReadOnly": false,
+	"Pc": 0 ,
+	"Gas": 766154147,
+	"GasRefund": -386980389124,
+	"Code": "",
+	"Stack": [
+	    "73d98e21930ee3c4 9adfe6af5c3129a6 14d8827ba8c91ac6 aad5465e39e7224f",
+	    "fbe73cec10215f25 b4b4cdc59461cf5e 0bdbdfbd8bb66463 8d8f315fa500dfd2",
+	    "44e536d9beb6692f f1771bc7786d984f e8121ed7845eb679 7481234b5f8357fc",
+	    "a4908db06f82ce80 fa765578d53df1b1 79aa3a06d8ea630a 5946bb7a396ca860",
+	    "5567e6eac386c167 503cbc87f4045ae3 03416fcf004cb556 f2339e0f9dad807a"
+    ]
+}


### PR DESCRIPTION
`returnData` is write only, therefore it should not be set in the CT state generation. RETURNDATASIZE and RETURNDATACOPY opcodes are reading from `lastCallReturnData`.