### PR TITLE
evmrs: use push guard to avoid stack overflow checks

### DIFF
--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -658,7 +658,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn add(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value2, value1]) = self.stack.pop_with_guard()?;
+        let (push_guard, [value2, value1]) = self.stack.pop_with_location()?;
         push_guard.push(value1 + value2);
         self.code_reader.next();
         self.return_from_op()
@@ -666,7 +666,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn mul(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [fac2, fac1]) = self.stack.pop_with_guard()?;
+        let (push_guard, [fac2, fac1]) = self.stack.pop_with_location()?;
         push_guard.push(fac1 * fac2);
         self.code_reader.next();
         self.return_from_op()
@@ -674,7 +674,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn sub(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value2, value1]) = self.stack.pop_with_guard()?;
+        let (push_guard, [value2, value1]) = self.stack.pop_with_location()?;
         push_guard.push(value1 - value2);
         self.code_reader.next();
         self.return_from_op()
@@ -682,7 +682,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn div(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [denominator, value]) = self.stack.pop_with_guard()?;
+        let (push_guard, [denominator, value]) = self.stack.pop_with_location()?;
         push_guard.push(value / denominator);
         self.code_reader.next();
         self.return_from_op()
@@ -690,7 +690,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn s_div(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [denominator, value]) = self.stack.pop_with_guard()?;
+        let (push_guard, [denominator, value]) = self.stack.pop_with_location()?;
         push_guard.push(value.sdiv(denominator));
         self.code_reader.next();
         self.return_from_op()
@@ -698,7 +698,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn mod_(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [denominator, value]) = self.stack.pop_with_guard()?;
+        let (push_guard, [denominator, value]) = self.stack.pop_with_location()?;
         push_guard.push(value % denominator);
         self.code_reader.next();
         self.return_from_op()
@@ -706,7 +706,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn s_mod(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [denominator, value]) = self.stack.pop_with_guard()?;
+        let (push_guard, [denominator, value]) = self.stack.pop_with_location()?;
         push_guard.push(value.srem(denominator));
         self.code_reader.next();
         self.return_from_op()
@@ -714,7 +714,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn add_mod(&mut self) -> OpResult {
         self.gas_left.consume(8)?;
-        let (push_guard, [denominator, value2, value1]) = self.stack.pop_with_guard()?;
+        let (push_guard, [denominator, value2, value1]) = self.stack.pop_with_location()?;
         push_guard.push(u256::addmod(value1, value2, denominator));
         self.code_reader.next();
         self.return_from_op()
@@ -722,7 +722,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn mul_mod(&mut self) -> OpResult {
         self.gas_left.consume(8)?;
-        let (push_guard, [denominator, fac2, fac1]) = self.stack.pop_with_guard()?;
+        let (push_guard, [denominator, fac2, fac1]) = self.stack.pop_with_location()?;
         push_guard.push(u256::mulmod(fac1, fac2, denominator));
         self.code_reader.next();
         self.return_from_op()
@@ -730,7 +730,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn exp(&mut self) -> OpResult {
         self.gas_left.consume(10)?;
-        let (push_guard, [exp, value]) = self.stack.pop_with_guard()?;
+        let (push_guard, [exp, value]) = self.stack.pop_with_location()?;
         self.gas_left.consume(exp.bits().div_ceil(8) as u64 * 50)?; // * does not overflow
         push_guard.push(value.pow(exp));
         self.code_reader.next();
@@ -739,7 +739,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn sign_extend(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [value, size]) = self.stack.pop_with_guard()?;
+        let (push_guard, [value, size]) = self.stack.pop_with_location()?;
         push_guard.push(u256::signextend(size, value));
         self.code_reader.next();
         self.return_from_op()
@@ -747,7 +747,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn lt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
         push_guard.push(lhs < rhs);
         self.code_reader.next();
         self.return_from_op()
@@ -755,7 +755,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn gt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
         push_guard.push(lhs > rhs);
         self.code_reader.next();
         self.return_from_op()
@@ -763,7 +763,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn s_lt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
         push_guard.push(lhs.slt(&rhs));
         self.code_reader.next();
         self.return_from_op()
@@ -771,7 +771,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn s_gt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
         push_guard.push(lhs.sgt(&rhs));
         self.code_reader.next();
         self.return_from_op()
@@ -779,7 +779,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn eq(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
         push_guard.push(lhs == rhs);
         self.code_reader.next();
         self.return_from_op()
@@ -787,7 +787,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn is_zero(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value]) = self.stack.pop_with_guard()?;
+        let (push_guard, [value]) = self.stack.pop_with_location()?;
         push_guard.push(value == u256::ZERO);
         self.code_reader.next();
         self.return_from_op()
@@ -795,7 +795,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn and(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
         push_guard.push(lhs & rhs);
         self.code_reader.next();
         self.return_from_op()
@@ -803,7 +803,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn or(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
         push_guard.push(lhs | rhs);
         self.code_reader.next();
         self.return_from_op()
@@ -811,7 +811,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn xor(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
         push_guard.push(lhs ^ rhs);
         self.code_reader.next();
         self.return_from_op()
@@ -819,7 +819,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn not(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value]) = self.stack.pop_with_guard()?;
+        let (push_guard, [value]) = self.stack.pop_with_location()?;
         push_guard.push(!value);
         self.code_reader.next();
         self.return_from_op()
@@ -827,7 +827,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn byte(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value, offset]) = self.stack.pop_with_guard()?;
+        let (push_guard, [value, offset]) = self.stack.pop_with_location()?;
         push_guard.push(value.byte(offset));
         self.code_reader.next();
         self.return_from_op()
@@ -835,7 +835,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn shl(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value, shift]) = self.stack.pop_with_guard()?;
+        let (push_guard, [value, shift]) = self.stack.pop_with_location()?;
         push_guard.push(value << shift);
         self.code_reader.next();
         self.return_from_op()
@@ -843,7 +843,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn shr(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value, shift]) = self.stack.pop_with_guard()?;
+        let (push_guard, [value, shift]) = self.stack.pop_with_location()?;
         push_guard.push(value >> shift);
         self.code_reader.next();
         self.return_from_op()
@@ -851,7 +851,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn sar(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value, shift]) = self.stack.pop_with_guard()?;
+        let (push_guard, [value, shift]) = self.stack.pop_with_location()?;
         push_guard.push(value.sar(shift));
         self.code_reader.next();
         self.return_from_op()
@@ -859,7 +859,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn sha3(&mut self) -> OpResult {
         self.gas_left.consume(30)?;
-        let (push_guard, [len, offset]) = self.stack.pop_with_guard()?;
+        let (push_guard, [len, offset]) = self.stack.pop_with_location()?;
 
         let len = u64::try_from(len).map_err(|_| FailStatus::OutOfGas)?;
         self.gas_left.consume(6 * word_size(len)?)?; // * does not overflow
@@ -881,7 +881,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         if self.revision < Revision::EVMC_BERLIN {
             self.gas_left.consume(700)?;
         }
-        let (push_guard, [addr]) = self.stack.pop_with_guard()?;
+        let (push_guard, [addr]) = self.stack.pop_with_location()?;
         let addr = addr.into();
         self.gas_left
             .consume_address_access_cost(&addr, self.revision, self.context)?;
@@ -913,7 +913,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn call_data_load(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [offset]) = self.stack.pop_with_guard()?;
+        let (push_guard, [offset]) = self.stack.pop_with_location()?;
         let (offset, overflow) = offset.into_u64_with_overflow();
         let offset = offset as usize;
         #[allow(clippy::map_identity)]
@@ -1026,7 +1026,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         if self.revision < Revision::EVMC_BERLIN {
             self.gas_left.consume(700)?;
         }
-        let (push_guard, [addr]) = self.stack.pop_with_guard()?;
+        let (push_guard, [addr]) = self.stack.pop_with_location()?;
         let addr = addr.into();
         self.gas_left
             .consume_address_access_cost(&addr, self.revision, self.context)?;
@@ -1102,7 +1102,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         if self.revision < Revision::EVMC_BERLIN {
             self.gas_left.consume(700)?;
         }
-        let (push_guard, [addr]) = self.stack.pop_with_guard()?;
+        let (push_guard, [addr]) = self.stack.pop_with_location()?;
         let addr = addr.into();
         self.gas_left
             .consume_address_access_cost(&addr, self.revision, self.context)?;
@@ -1113,7 +1113,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn block_hash(&mut self) -> OpResult {
         self.gas_left.consume(20)?;
-        let (push_guard, [block_number]) = self.stack.pop_with_guard()?;
+        let (push_guard, [block_number]) = self.stack.pop_with_location()?;
         push_guard.push(
             u64::try_from(block_number)
                 .map(|idx| self.context.get_block_hash(idx as i64).into())
@@ -1195,7 +1195,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
     fn blob_hash(&mut self) -> OpResult {
         check_min_revision(Revision::EVMC_CANCUN, self.revision)?;
         self.gas_left.consume(3)?;
-        let (push_guard, [idx]) = self.stack.pop_with_guard()?;
+        let (push_guard, [idx]) = self.stack.pop_with_location()?;
         let (idx, idx_overflow) = idx.into_u64_with_overflow();
         let idx = idx as usize;
         let hashes = ExecutionTxContext::from(self.context.get_tx_context()).blob_hashes;
@@ -1226,7 +1226,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn m_load(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [offset]) = self.stack.pop_with_guard()?;
+        let (push_guard, [offset]) = self.stack.pop_with_location()?;
 
         push_guard.push(self.memory.get_word(offset, &mut self.gas_left)?);
         self.code_reader.next();
@@ -1258,7 +1258,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         if self.revision < Revision::EVMC_BERLIN {
             self.gas_left.consume(800)?;
         }
-        let (push_guard, [key]) = self.stack.pop_with_guard()?;
+        let (push_guard, [key]) = self.stack.pop_with_location()?;
         let key = key.into();
         let addr = self.message.recipient();
         if self.revision >= Revision::EVMC_BERLIN {
@@ -1329,7 +1329,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
     fn t_load(&mut self) -> OpResult {
         check_min_revision(Revision::EVMC_CANCUN, self.revision)?;
         self.gas_left.consume(100)?;
-        let (push_guard, [key]) = self.stack.pop_with_guard()?;
+        let (push_guard, [key]) = self.stack.pop_with_location()?;
         let addr = self.message.recipient();
         let value = self.context.get_transient_storage(addr, &key.into());
         push_guard.push(value);

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -658,214 +658,214 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn add(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value2, value1]) = self.stack.pop_with_location()?;
-        push_guard.push(value1 + value2);
+        let (push_location, [value2, value1]) = self.stack.pop_with_location()?;
+        push_location.push(value1 + value2);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn mul(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [fac2, fac1]) = self.stack.pop_with_location()?;
-        push_guard.push(fac1 * fac2);
+        let (push_location, [fac2, fac1]) = self.stack.pop_with_location()?;
+        push_location.push(fac1 * fac2);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn sub(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value2, value1]) = self.stack.pop_with_location()?;
-        push_guard.push(value1 - value2);
+        let (push_location, [value2, value1]) = self.stack.pop_with_location()?;
+        push_location.push(value1 - value2);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn div(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [denominator, value]) = self.stack.pop_with_location()?;
-        push_guard.push(value / denominator);
+        let (push_location, [denominator, value]) = self.stack.pop_with_location()?;
+        push_location.push(value / denominator);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn s_div(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [denominator, value]) = self.stack.pop_with_location()?;
-        push_guard.push(value.sdiv(denominator));
+        let (push_location, [denominator, value]) = self.stack.pop_with_location()?;
+        push_location.push(value.sdiv(denominator));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn mod_(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [denominator, value]) = self.stack.pop_with_location()?;
-        push_guard.push(value % denominator);
+        let (push_location, [denominator, value]) = self.stack.pop_with_location()?;
+        push_location.push(value % denominator);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn s_mod(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [denominator, value]) = self.stack.pop_with_location()?;
-        push_guard.push(value.srem(denominator));
+        let (push_location, [denominator, value]) = self.stack.pop_with_location()?;
+        push_location.push(value.srem(denominator));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn add_mod(&mut self) -> OpResult {
         self.gas_left.consume(8)?;
-        let (push_guard, [denominator, value2, value1]) = self.stack.pop_with_location()?;
-        push_guard.push(u256::addmod(value1, value2, denominator));
+        let (push_location, [denominator, value2, value1]) = self.stack.pop_with_location()?;
+        push_location.push(u256::addmod(value1, value2, denominator));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn mul_mod(&mut self) -> OpResult {
         self.gas_left.consume(8)?;
-        let (push_guard, [denominator, fac2, fac1]) = self.stack.pop_with_location()?;
-        push_guard.push(u256::mulmod(fac1, fac2, denominator));
+        let (push_location, [denominator, fac2, fac1]) = self.stack.pop_with_location()?;
+        push_location.push(u256::mulmod(fac1, fac2, denominator));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn exp(&mut self) -> OpResult {
         self.gas_left.consume(10)?;
-        let (push_guard, [exp, value]) = self.stack.pop_with_location()?;
+        let (push_location, [exp, value]) = self.stack.pop_with_location()?;
         self.gas_left.consume(exp.bits().div_ceil(8) as u64 * 50)?; // * does not overflow
-        push_guard.push(value.pow(exp));
+        push_location.push(value.pow(exp));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn sign_extend(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let (push_guard, [value, size]) = self.stack.pop_with_location()?;
-        push_guard.push(u256::signextend(size, value));
+        let (push_location, [value, size]) = self.stack.pop_with_location()?;
+        push_location.push(u256::signextend(size, value));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn lt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
-        push_guard.push(lhs < rhs);
+        let (push_location, [rhs, lhs]) = self.stack.pop_with_location()?;
+        push_location.push(lhs < rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn gt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
-        push_guard.push(lhs > rhs);
+        let (push_location, [rhs, lhs]) = self.stack.pop_with_location()?;
+        push_location.push(lhs > rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn s_lt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
-        push_guard.push(lhs.slt(&rhs));
+        let (push_location, [rhs, lhs]) = self.stack.pop_with_location()?;
+        push_location.push(lhs.slt(&rhs));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn s_gt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
-        push_guard.push(lhs.sgt(&rhs));
+        let (push_location, [rhs, lhs]) = self.stack.pop_with_location()?;
+        push_location.push(lhs.sgt(&rhs));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn eq(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
-        push_guard.push(lhs == rhs);
+        let (push_location, [rhs, lhs]) = self.stack.pop_with_location()?;
+        push_location.push(lhs == rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn is_zero(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value]) = self.stack.pop_with_location()?;
-        push_guard.push(value == u256::ZERO);
+        let (push_location, [value]) = self.stack.pop_with_location()?;
+        push_location.push(value == u256::ZERO);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn and(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
-        push_guard.push(lhs & rhs);
+        let (push_location, [rhs, lhs]) = self.stack.pop_with_location()?;
+        push_location.push(lhs & rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn or(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
-        push_guard.push(lhs | rhs);
+        let (push_location, [rhs, lhs]) = self.stack.pop_with_location()?;
+        push_location.push(lhs | rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn xor(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [rhs, lhs]) = self.stack.pop_with_location()?;
-        push_guard.push(lhs ^ rhs);
+        let (push_location, [rhs, lhs]) = self.stack.pop_with_location()?;
+        push_location.push(lhs ^ rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn not(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value]) = self.stack.pop_with_location()?;
-        push_guard.push(!value);
+        let (push_location, [value]) = self.stack.pop_with_location()?;
+        push_location.push(!value);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn byte(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value, offset]) = self.stack.pop_with_location()?;
-        push_guard.push(value.byte(offset));
+        let (push_location, [value, offset]) = self.stack.pop_with_location()?;
+        push_location.push(value.byte(offset));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn shl(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value, shift]) = self.stack.pop_with_location()?;
-        push_guard.push(value << shift);
+        let (push_location, [value, shift]) = self.stack.pop_with_location()?;
+        push_location.push(value << shift);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn shr(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value, shift]) = self.stack.pop_with_location()?;
-        push_guard.push(value >> shift);
+        let (push_location, [value, shift]) = self.stack.pop_with_location()?;
+        push_location.push(value >> shift);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn sar(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [value, shift]) = self.stack.pop_with_location()?;
-        push_guard.push(value.sar(shift));
+        let (push_location, [value, shift]) = self.stack.pop_with_location()?;
+        push_location.push(value.sar(shift));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn sha3(&mut self) -> OpResult {
         self.gas_left.consume(30)?;
-        let (push_guard, [len, offset]) = self.stack.pop_with_location()?;
+        let (push_location, [len, offset]) = self.stack.pop_with_location()?;
 
         let len = u64::try_from(len).map_err(|_| FailStatus::OutOfGas)?;
         self.gas_left.consume(6 * word_size(len)?)?; // * does not overflow
 
         let data = self.memory.get_mut_slice(offset, len, &mut self.gas_left)?;
-        push_guard.push(hash_cache::hash(data));
+        push_location.push(hash_cache::hash(data));
         self.code_reader.next();
         self.return_from_op()
     }
@@ -881,11 +881,11 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         if self.revision < Revision::EVMC_BERLIN {
             self.gas_left.consume(700)?;
         }
-        let (push_guard, [addr]) = self.stack.pop_with_location()?;
+        let (push_location, [addr]) = self.stack.pop_with_location()?;
         let addr = addr.into();
         self.gas_left
             .consume_address_access_cost(&addr, self.revision, self.context)?;
-        push_guard.push(self.context.get_balance(&addr));
+        push_location.push(self.context.get_balance(&addr));
         self.code_reader.next();
         self.return_from_op()
     }
@@ -913,7 +913,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn call_data_load(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [offset]) = self.stack.pop_with_location()?;
+        let (push_location, [offset]) = self.stack.pop_with_location()?;
         let (offset, overflow) = offset.into_u64_with_overflow();
         let offset = offset as usize;
         #[allow(clippy::map_identity)]
@@ -928,12 +928,12 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
             )
             .unwrap_or_default();
         if overflow || offset >= call_data.len() {
-            push_guard.push(u256::ZERO);
+            push_location.push(u256::ZERO);
         } else {
             let end = min(call_data.len(), offset + 32);
             let mut bytes = [0; 32];
             bytes[..end - offset].copy_from_slice(&call_data[offset..end]);
-            push_guard.push(u256::from_be_bytes(bytes));
+            push_location.push(u256::from_be_bytes(bytes));
         }
         self.code_reader.next();
         self.return_from_op()
@@ -1026,11 +1026,11 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         if self.revision < Revision::EVMC_BERLIN {
             self.gas_left.consume(700)?;
         }
-        let (push_guard, [addr]) = self.stack.pop_with_location()?;
+        let (push_location, [addr]) = self.stack.pop_with_location()?;
         let addr = addr.into();
         self.gas_left
             .consume_address_access_cost(&addr, self.revision, self.context)?;
-        push_guard.push(self.context.get_code_size(&addr));
+        push_location.push(self.context.get_code_size(&addr));
         self.code_reader.next();
         self.return_from_op()
     }
@@ -1102,19 +1102,19 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         if self.revision < Revision::EVMC_BERLIN {
             self.gas_left.consume(700)?;
         }
-        let (push_guard, [addr]) = self.stack.pop_with_location()?;
+        let (push_location, [addr]) = self.stack.pop_with_location()?;
         let addr = addr.into();
         self.gas_left
             .consume_address_access_cost(&addr, self.revision, self.context)?;
-        push_guard.push(self.context.get_code_hash(&addr));
+        push_location.push(self.context.get_code_hash(&addr));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn block_hash(&mut self) -> OpResult {
         self.gas_left.consume(20)?;
-        let (push_guard, [block_number]) = self.stack.pop_with_location()?;
-        push_guard.push(
+        let (push_location, [block_number]) = self.stack.pop_with_location()?;
+        push_location.push(
             u64::try_from(block_number)
                 .map(|idx| self.context.get_block_hash(idx as i64).into())
                 .unwrap_or(u256::ZERO),
@@ -1195,14 +1195,14 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
     fn blob_hash(&mut self) -> OpResult {
         check_min_revision(Revision::EVMC_CANCUN, self.revision)?;
         self.gas_left.consume(3)?;
-        let (push_guard, [idx]) = self.stack.pop_with_location()?;
+        let (push_location, [idx]) = self.stack.pop_with_location()?;
         let (idx, idx_overflow) = idx.into_u64_with_overflow();
         let idx = idx as usize;
         let hashes = ExecutionTxContext::from(self.context.get_tx_context()).blob_hashes;
         if !idx_overflow && idx < hashes.len() {
-            push_guard.push(hashes[idx]);
+            push_location.push(hashes[idx]);
         } else {
-            push_guard.push(u256::ZERO);
+            push_location.push(u256::ZERO);
         }
         self.code_reader.next();
         self.return_from_op()
@@ -1226,9 +1226,9 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn m_load(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let (push_guard, [offset]) = self.stack.pop_with_location()?;
+        let (push_location, [offset]) = self.stack.pop_with_location()?;
 
-        push_guard.push(self.memory.get_word(offset, &mut self.gas_left)?);
+        push_location.push(self.memory.get_word(offset, &mut self.gas_left)?);
         self.code_reader.next();
         self.return_from_op()
     }
@@ -1258,7 +1258,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         if self.revision < Revision::EVMC_BERLIN {
             self.gas_left.consume(800)?;
         }
-        let (push_guard, [key]) = self.stack.pop_with_location()?;
+        let (push_location, [key]) = self.stack.pop_with_location()?;
         let key = key.into();
         let addr = self.message.recipient();
         if self.revision >= Revision::EVMC_BERLIN {
@@ -1269,7 +1269,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
             }
         }
         let value = self.context.get_storage(addr, &key);
-        push_guard.push(value);
+        push_location.push(value);
         self.code_reader.next();
         self.return_from_op()
     }
@@ -1329,10 +1329,10 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
     fn t_load(&mut self) -> OpResult {
         check_min_revision(Revision::EVMC_CANCUN, self.revision)?;
         self.gas_left.consume(100)?;
-        let (push_guard, [key]) = self.stack.pop_with_location()?;
+        let (push_location, [key]) = self.stack.pop_with_location()?;
         let addr = self.message.recipient();
         let value = self.context.get_transient_storage(addr, &key.into());
-        push_guard.push(value);
+        push_location.push(value);
         self.code_reader.next();
         self.return_from_op()
     }

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -658,32 +658,32 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn add(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [value2, value1] = self.stack.pop()?;
-        self.stack.push(value1 + value2)?;
+        let (push_guard, [value2, value1]) = self.stack.pop_with_guard()?;
+        push_guard.push(value1 + value2);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn mul(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let [fac2, fac1] = self.stack.pop()?;
-        self.stack.push(fac1 * fac2)?;
+        let (push_guard, [fac2, fac1]) = self.stack.pop_with_guard()?;
+        push_guard.push(fac1 * fac2);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn sub(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [value2, value1] = self.stack.pop()?;
-        self.stack.push(value1 - value2)?;
+        let (push_guard, [value2, value1]) = self.stack.pop_with_guard()?;
+        push_guard.push(value1 - value2);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn div(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let [denominator, value] = self.stack.pop()?;
-        self.stack.push(value / denominator)?;
+        let (push_guard, [denominator, value]) = self.stack.pop_with_guard()?;
+        push_guard.push(value / denominator);
         self.code_reader.next();
         self.return_from_op()
     }
@@ -698,8 +698,8 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn mod_(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let [denominator, value] = self.stack.pop()?;
-        self.stack.push(value % denominator)?;
+        let (push_guard, [denominator, value]) = self.stack.pop_with_guard()?;
+        push_guard.push(value % denominator);
         self.code_reader.next();
         self.return_from_op()
     }

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -690,8 +690,8 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn s_div(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let [denominator, value] = self.stack.pop()?;
-        self.stack.push(value.sdiv(denominator))?;
+        let (push_guard, [denominator, value]) = self.stack.pop_with_guard()?;
+        push_guard.push(value.sdiv(denominator));
         self.code_reader.next();
         self.return_from_op()
     }
@@ -706,153 +706,153 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
 
     fn s_mod(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let [denominator, value] = self.stack.pop()?;
-        self.stack.push(value.srem(denominator))?;
+        let (push_guard, [denominator, value]) = self.stack.pop_with_guard()?;
+        push_guard.push(value.srem(denominator));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn add_mod(&mut self) -> OpResult {
         self.gas_left.consume(8)?;
-        let [denominator, value2, value1] = self.stack.pop()?;
-        self.stack.push(u256::addmod(value1, value2, denominator))?;
+        let (push_guard, [denominator, value2, value1]) = self.stack.pop_with_guard()?;
+        push_guard.push(u256::addmod(value1, value2, denominator));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn mul_mod(&mut self) -> OpResult {
         self.gas_left.consume(8)?;
-        let [denominator, fac2, fac1] = self.stack.pop()?;
-        self.stack.push(u256::mulmod(fac1, fac2, denominator))?;
+        let (push_guard, [denominator, fac2, fac1]) = self.stack.pop_with_guard()?;
+        push_guard.push(u256::mulmod(fac1, fac2, denominator));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn exp(&mut self) -> OpResult {
         self.gas_left.consume(10)?;
-        let [exp, value] = self.stack.pop()?;
+        let (push_guard, [exp, value]) = self.stack.pop_with_guard()?;
         self.gas_left.consume(exp.bits().div_ceil(8) as u64 * 50)?; // * does not overflow
-        self.stack.push(value.pow(exp))?;
+        push_guard.push(value.pow(exp));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn sign_extend(&mut self) -> OpResult {
         self.gas_left.consume(5)?;
-        let [value, size] = self.stack.pop()?;
-        self.stack.push(u256::signextend(size, value))?;
+        let (push_guard, [value, size]) = self.stack.pop_with_guard()?;
+        push_guard.push(u256::signextend(size, value));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn lt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [rhs, lhs] = self.stack.pop()?;
-        self.stack.push(lhs < rhs)?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        push_guard.push(lhs < rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn gt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [rhs, lhs] = self.stack.pop()?;
-        self.stack.push(lhs > rhs)?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        push_guard.push(lhs > rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn s_lt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [rhs, lhs] = self.stack.pop()?;
-        self.stack.push(lhs.slt(&rhs))?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        push_guard.push(lhs.slt(&rhs));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn s_gt(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [rhs, lhs] = self.stack.pop()?;
-        self.stack.push(lhs.sgt(&rhs))?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        push_guard.push(lhs.sgt(&rhs));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn eq(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [rhs, lhs] = self.stack.pop()?;
-        self.stack.push(lhs == rhs)?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        push_guard.push(lhs == rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn is_zero(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [value] = self.stack.pop()?;
-        self.stack.push(value == u256::ZERO)?;
+        let (push_guard, [value]) = self.stack.pop_with_guard()?;
+        push_guard.push(value == u256::ZERO);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn and(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [rhs, lhs] = self.stack.pop()?;
-        self.stack.push(lhs & rhs)?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        push_guard.push(lhs & rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn or(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [rhs, lhs] = self.stack.pop()?;
-        self.stack.push(lhs | rhs)?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        push_guard.push(lhs | rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn xor(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [rhs, lhs] = self.stack.pop()?;
-        self.stack.push(lhs ^ rhs)?;
+        let (push_guard, [rhs, lhs]) = self.stack.pop_with_guard()?;
+        push_guard.push(lhs ^ rhs);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn not(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [value] = self.stack.pop()?;
-        self.stack.push(!value)?;
+        let (push_guard, [value]) = self.stack.pop_with_guard()?;
+        push_guard.push(!value);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn byte(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [value, offset] = self.stack.pop()?;
-        self.stack.push(value.byte(offset))?;
+        let (push_guard, [value, offset]) = self.stack.pop_with_guard()?;
+        push_guard.push(value.byte(offset));
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn shl(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [value, shift] = self.stack.pop()?;
-        self.stack.push(value << shift)?;
+        let (push_guard, [value, shift]) = self.stack.pop_with_guard()?;
+        push_guard.push(value << shift);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn shr(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [value, shift] = self.stack.pop()?;
-        self.stack.push(value >> shift)?;
+        let (push_guard, [value, shift]) = self.stack.pop_with_guard()?;
+        push_guard.push(value >> shift);
         self.code_reader.next();
         self.return_from_op()
     }
 
     fn sar(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
-        let [value, shift] = self.stack.pop()?;
-        self.stack.push(value.sar(shift))?;
+        let (push_guard, [value, shift]) = self.stack.pop_with_guard()?;
+        push_guard.push(value.sar(shift));
         self.code_reader.next();
         self.return_from_op()
     }

--- a/rust/src/types/stack.rs
+++ b/rust/src/types/stack.rs
@@ -10,9 +10,16 @@ impl<const N: usize> NonZero<N> {
     const VALID: () = assert!(N > 0);
 }
 
-/// Wrapper around [`&mut u256`] that ensures that the only possible operation is to write once to
-/// this memory location.
+/// This type is created by calling [`Stack::pop_with_location`] and is intended to replace pushing
+/// to the stack directly. It and avoids the stack overflow check when pushing because it is no
+/// longer needed. [`PushLocation`] has to be consumed by pushing to it.
+/// If this does not happen, the program is still memory safe, however there will be one item so
+/// much on the stack.
+///
+/// Internally it is a wrapper around [`&mut u256`] that ensures that the only possible operation is
+/// to write once to this memory location.
 #[derive(Debug)]
+#[must_use = "PushLocation has to be pushed to."]
 pub struct PushLocation<'p>(&'p mut u256);
 
 impl PushLocation<'_> {

--- a/rust/src/types/stack.rs
+++ b/rust/src/types/stack.rs
@@ -12,9 +12,9 @@ impl<const N: usize> NonZero<N> {
 
 /// Wrapper around [`&mut u256`] that ensures that the only possible operation is to write once to
 /// this memory location.
-pub struct PushGuard<'p>(&'p mut u256);
+pub struct PushLocation<'p>(&'p mut u256);
 
-impl PushGuard<'_> {
+impl PushLocation<'_> {
     pub fn push(self, value: impl Into<u256>) {
         *self.0 = value.into();
     }
@@ -124,7 +124,9 @@ impl Stack {
         Ok(array)
     }
 
-    pub fn pop_with_guard<const N: usize>(&mut self) -> Result<(PushGuard, [u256; N]), FailStatus> {
+    pub fn pop_with_location<const N: usize>(
+        &mut self,
+    ) -> Result<(PushLocation, [u256; N]), FailStatus> {
         self.check_underflow(N)?;
 
         self.0.truncate(self.len() - (N - 1));
@@ -138,7 +140,7 @@ impl Stack {
         // starting at index `self.len - 1` as an array of length N and type u256.
         let pop_data = unsafe { *(pop_start as *const [u256; N]) };
         let len = self.len();
-        let push_guard = PushGuard(&mut self.0[len - 1]);
+        let push_guard = PushLocation(&mut self.0[len - 1]);
         Ok((push_guard, pop_data))
     }
 


### PR DESCRIPTION
This PR adds the method `pop_with_guard` to Stack, which works similar to the normal `pop` method, but additionally returns a PushGuard which holds a mutable reference to the location in the stack where the result can be pushed to. Because we popped values first, pushing a single value will never overflow the stack. 
Unfortunately, when first poping values and then pushing a single value, the compiler does not figure this out and adds the check for the (evm)stack overflow. With this optimization, this check is now gone.
While this optimization does decrease performance on old hardware (probably because of code layout reasons), it does improve performance on new hardware, which is what matters at the end of the day.

```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/integration_test/interpreter
cpu: AMD EPYC 7713 64-Core Processor                
                   │ 2025-01-08T09:35#4da02ec#20-main/evmrs#performance │ 2025-01-09T14:11#2574774#20/evmrs#performance │
                   │                       sec/op                       │         sec/op          vs base               │
StaticOverhead/1/                                           900.9n ± 0%              897.4n ± 0%       ~ (p=0.106 n=20)
Inc/1/                                                      1.912µ ± 1%              1.904µ ± 0%  -0.42% (p=0.031 n=20)
Inc/10/                                                     1.918µ ± 0%              1.862µ ± 0%  -2.92% (p=0.000 n=20)
Fib/1/                                                      1.688µ ± 1%              1.646µ ± 0%  -2.49% (p=0.000 n=20)
Fib/5/                                                      8.405µ ± 0%              8.308µ ± 4%       ~ (p=0.286 n=20)
Fib/10/                                                     89.09µ ± 0%              89.13µ ± 0%       ~ (p=0.507 n=20)
Fib/15/                                                     931.9µ ± 1%              924.7µ ± 1%  -0.77% (p=0.020 n=20)
Fib/20/                                                     10.36m ± 1%              10.20m ± 1%  -1.47% (p=0.001 n=20)
Sha3/1/                                                     1.088µ ± 0%              1.063µ ± 0%  -2.25% (p=0.000 n=20)
Sha3/10/                                                    1.837µ ± 0%              1.800µ ± 0%  -2.01% (p=0.000 n=20)
Sha3/100/                                                   9.357µ ± 0%              9.217µ ± 0%  -1.51% (p=0.000 n=20)
Sha3/1000/                                                  87.29µ ± 0%              85.71µ ± 0%  -1.81% (p=0.000 n=20)
Arith/1/                                                    2.081µ ± 0%              2.189µ ± 1%  +5.19% (p=0.000 n=20)
Arith/10/                                                   4.841µ ± 1%              4.841µ ± 4%       ~ (p=0.213 n=20)
Arith/100/                                                  32.08µ ± 0%              31.68µ ± 0%  -1.23% (p=0.000 n=20)
Arith/280/                                                 101.27µ ± 7%              91.41µ ± 1%  -9.74% (p=0.000 n=20)
Memory/1/                                                   2.886µ ± 1%              2.799µ ± 0%  -3.02% (p=0.000 n=20)
Memory/10/                                                  6.193µ ± 0%              6.096µ ± 1%  -1.56% (p=0.000 n=20)
Memory/100/                                                 39.37µ ± 0%              36.71µ ± 0%  -6.76% (p=0.000 n=20)
Memory/1000/                                                373.5µ ± 0%              366.3µ ± 0%  -1.94% (p=0.000 n=20)
Memory/10000/                                               3.617m ± 0%              3.347m ± 6%  -7.47% (p=0.000 n=20)
Analysis/jumpdest/                                          927.1n ± 0%              913.4n ± 0%  -1.47% (p=0.000 n=20)
Analysis/stop/                                              939.8n ± 0%              917.4n ± 0%  -2.38% (p=0.000 n=20)
Analysis/push1/                                             937.2n ± 1%              917.1n ± 0%  -2.15% (p=0.000 n=20)
Analysis/push32/                                            945.2n ± 1%              912.9n ± 0%  -3.42% (p=0.000 n=20)
geomean                                                     12.24µ                   11.98µ       -2.16%
```