### PR TITLE
no bounds checks in get_push_data

### DIFF
--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -115,8 +115,20 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
     }
     #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
     pub fn get_push_data(&mut self) -> u256 {
+        // SAFETY:
+        // This assertion assumes that the program counter (self.pc) was not modified after calling
+        // [`CodeReader::get`]. While this can not be guaranteed here, marking the function
+        // as unsafe would propagate all the way to the function dispatch function and also require
+        // that all opcode functions are unsafe. In practice, the only way to modify the
+        // program counter, is through one of the functions of CodeReader that take it by mutable
+        // reference. Those are next, try_jump, jump_to and get_push_data itself.
+        // Calling those and then calling get_push_data makes semantically no sense.
+        unsafe {
+            std::hint::assert_unchecked(self.pc < self.code_analysis.analysis.len());
+        }
+        let res = self.code_analysis.analysis[self.pc].get_data();
         self.pc += 1;
-        self.code_analysis.analysis[self.pc - 1].get_data()
+        res
     }
     #[cfg(all(
         not(feature = "fn-ptr-conversion-expanded-dispatch"),


### PR DESCRIPTION
This PR adds unsafe compiler hints to remove bound checks.
The idea is that when feature fn-ptr-conversion-expanded-dispatch is enabled, the analysis item holds both the function pointer for the corresponding opcode impl and a u256 used as push data.
The function pointer is retrieved first in order to call the function.
In case the function is Interpreter::push, it calls get_push_data to get the data to push onto the stack.
Because we already retrieved the function pointer, and the pc was not modified in between, it is not necessary to check the bounds again when accessing the same analysis item again to get the push data.