### PR TITLE
evmrs: add feature unsafe-hints

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ needs-cache = ["dep:lru"]
 performance = [
     "mimalloc",
     "unsafe-stack",
+    "unsafe-hints",
     "custom-evmc",
     "hash-cache",
     "code-analysis-cache",
@@ -36,6 +37,7 @@ performance = [
 ]
 mimalloc = ["dep:mimalloc"]
 unsafe-stack = []
+unsafe-hints = []
 custom-evmc = ["dep:evmc-vm-tosca-refactor"]
 hash-cache = ["needs-cache"]
 code-analysis-cache = ["dep:nohash-hasher", "needs-cache"]

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -1238,7 +1238,10 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         let [value, offset] = self.stack.pop()?;
 
         let dest = self.memory.get_mut_slice(offset, 32, &mut self.gas_left)?;
-        dest.copy_from_slice(&value.to_le_bytes());
+        // SAFETY:
+        // dest is 32 bytes long and can be cast to a &mut [u8; 32].
+        let dest = unsafe { &mut *(dest.as_mut_ptr() as *mut [u8; 32]) };
+        *dest = value.to_le_bytes();
         dest.reverse();
         self.code_reader.next();
         self.return_from_op()

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -123,6 +123,7 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
         // program counter, is through one of the functions of CodeReader that take it by mutable
         // reference. Those are next, try_jump, jump_to and get_push_data itself.
         // Calling those and then calling get_push_data makes semantically no sense.
+        #[cfg(feature = "unsafe-hints")]
         unsafe {
             std::hint::assert_unchecked(self.pc < self.code_analysis.analysis.len());
         }

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -90,7 +90,12 @@ impl Memory {
         }
         self.expand(end, gas_left)?;
 
-        Ok(&mut self.0[offset as usize..end as usize])
+        let offset = offset as usize;
+        let end = end as usize;
+        unsafe {
+            std::hint::assert_unchecked(offset < end && end <= self.0.len());
+        }
+        Ok(&mut self.0[offset..end])
     }
 
     pub fn get_word(&mut self, offset: u256, gas_left: &mut Gas) -> Result<u256, FailStatus> {

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -98,8 +98,13 @@ impl Memory {
 
         let offset = offset as usize;
         let end = end as usize;
+        #[cfg(feature = "unsafe-hints")]
+        // SAFETY:
+        // end = offset + len, so offset <= end
+        // end will always be in bounds because expand takes care of expanding the memory
+        // accordingly.
         unsafe {
-            std::hint::assert_unchecked(offset < end && end <= self.0.len());
+            std::hint::assert_unchecked(offset <= end && end <= self.0.len());
         }
         Ok(&mut self.0[offset..end])
     }


### PR DESCRIPTION
This PR adds more unsafe compiler hints to eliminate bound checks and puts those behind the new feature `unsafe-hints`.

- assert that the slice in m_store is 32 bytes long
- assert that the memory access after memory expansion is always in bounds
- put the existing hint of #10 also behind the new feature

Additionally, the part of the memory expansion function which is responsible for the actual expansion (not the checks if an expansion is needed) is extracted into a separate function so that the checks without the expansions get inlined.