### PR TITLE
evmrs: cleanup

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 # feature mock enables code generation for test mocking. This allows generating mocks for other build configuration but "test". 
 mock = ["dep:mockall"]
 fuzzing = ["dep:arbitrary"]
-# partial features (enabled by other features to simplyfy conditional compilation attributes. Not intended to be used on their own)
+# partial features (enabled by other features to simplify conditional compilation attributes. Not intended to be used on their own)
 needs-jumptable = []
 needs-fn-ptr-conversion = ["needs-jumptable"]
 needs-cache = ["dep:lru"]
@@ -32,7 +32,6 @@ performance = [
     "hash-cache",
     "code-analysis-cache",
     "alloc-reuse",
-    "jumptable-dispatch",
     "fn-ptr-conversion-expanded-dispatch",
 ]
 mimalloc = ["dep:mimalloc"]
@@ -44,11 +43,11 @@ code-analysis-cache = ["dep:nohash-hasher", "needs-cache"]
 thread-local-cache = []
 alloc-reuse = []
 tail-call = []
+# function/ opcode dispatch:
+# feature precedence: switch-dispatch (default) < jumptable-dispatch < fn-ptr-conversion-inline-dispatch < fn-ptr-conversion-expanded-dispatch
 jumptable-dispatch = ["needs-jumptable"]
-# fn-ptr-conversion takes precedence over jumptable, switch (default) and fn-ptr-conversion-inline
-fn-ptr-conversion-expanded-dispatch = ["needs-fn-ptr-conversion"]
-# fn-ptr-conversion-inline takes precedence over jumptable and switch (default)
 fn-ptr-conversion-inline-dispatch = ["needs-fn-ptr-conversion"]
+fn-ptr-conversion-expanded-dispatch = ["needs-fn-ptr-conversion"]
 
 [dependencies]
 bnum = "0.12.0"

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -1483,7 +1483,6 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         self.return_from_op()
     }
 
-    #[allow(unused_variables)]
     fn push<const N: usize>(&mut self) -> OpResult {
         self.gas_left.consume(3)?;
         #[cfg(not(feature = "fn-ptr-conversion-expanded-dispatch"))]

--- a/rust/src/types/stack.rs
+++ b/rust/src/types/stack.rs
@@ -150,8 +150,8 @@ impl Stack {
         // starting at index `self.len - 1` as an array of length N and type u256.
         let pop_data = unsafe { *(pop_start as *const [u256; N]) };
         let len = self.len();
-        let push_guard = PushLocation(&mut self.0[len - 1]);
-        Ok((push_guard, pop_data))
+        let push_location = PushLocation(&mut self.0[len - 1]);
+        Ok((push_location, pop_data))
     }
 
     pub fn peek(&self) -> Option<&u256> {
@@ -221,9 +221,9 @@ mod tests {
     #[test]
     fn pop_with_location() {
         let mut stack = Stack::new(&[u256::MAX]);
-        let (guard, data) = stack.pop_with_location::<1>().unwrap();
+        let (push_location, data) = stack.pop_with_location::<1>().unwrap();
         assert_eq!(data, [u256::MAX]);
-        guard.push(u256::ONE);
+        push_location.push(u256::ONE);
         assert_eq!(stack.as_slice(), [u256::ONE]);
 
         let mut stack = Stack::new(&[]);
@@ -233,9 +233,9 @@ mod tests {
         );
 
         let mut stack = Stack::new(&[u256::ONE, u256::MAX]);
-        let (guard, data) = stack.pop_with_location::<2>().unwrap();
+        let (push_location, data) = stack.pop_with_location::<2>().unwrap();
         assert_eq!(data, [u256::ONE, u256::MAX]);
-        guard.push(u256::ZERO);
+        push_location.push(u256::ZERO);
         assert_eq!(stack.as_slice(), [u256::ZERO]);
 
         let mut stack = Stack::new(&[u256::MAX]);


### PR DESCRIPTION
- remove jumptable-dispatch from performance feature, because fn-ptr-conversion-expanded-dispatch has higher precedence anyway
- specify precedence of function dispatch features in Cargo.toml
- remove unnecessary lint suppression
- fix typos and outdated variable names