### PR TITLE
Geth processor reference implementation

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -92,6 +92,8 @@ override:
   - threshold: 0
     path: go/processor/floria
   - threshold: 0
+    path: go/processor/geth
+  - threshold: 0
     path: go/processor/opera
   - threshold: 0
     path: go/tosca

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 
 require (
 	github.com/DataDog/zstd v1.4.5 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -48,6 +49,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c // indirect
 	github.com/crate-crypto/go-kzg-4844 v1.0.0 // indirect
+	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/ethereum/c-kzg-4844 v1.0.0 // indirect
 	github.com/ethereum/go-verkle v0.1.1-0.20240306133620-7d920df305f0 // indirect
@@ -57,6 +59,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/klauspost/compress v1.16.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
@@ -106,6 +108,8 @@ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=
+github.com/deckarep/golang-set/v2 v2.6.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
@@ -207,6 +211,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=

--- a/go/integration_test/processor/gas_billing_test.go
+++ b/go/integration_test/processor/gas_billing_test.go
@@ -19,7 +19,9 @@ import (
 	op "github.com/ethereum/go-ethereum/core/vm"
 	"go.uber.org/mock/gomock"
 
-	_ "github.com/0xsoniclabs/tosca/go/processor/opera" // < registers opera processor for testing
+	_ "github.com/0xsoniclabs/tosca/go/processor/floria" // < registers floria processor for testing
+	_ "github.com/0xsoniclabs/tosca/go/processor/geth"   // < registers geth processor for testing
+	_ "github.com/0xsoniclabs/tosca/go/processor/opera"  // < registers opera processor for testing
 )
 
 func TestProcessor_GasBillingEndToEnd(t *testing.T) {

--- a/go/integration_test/processor/processor_test.go
+++ b/go/integration_test/processor/processor_test.go
@@ -222,7 +222,7 @@ func TestGetProcessors_ContainsMainConfigurations(t *testing.T) {
 	wanted := []string{
 		"opera/geth", "opera/lfvm", "opera/evmzero",
 		"floria/geth", "floria/lfvm", "floria/evmzero",
-		"geth-ftm/geth", "geth-ftm/lfvm", "geth-ftm/evmzero",
+		"geth-sonic/geth", "geth-sonic/lfvm", "geth-sonic/evmzero",
 	}
 	for _, n := range wanted {
 		if !slices.Contains(all, n) {

--- a/go/integration_test/processor/processor_test.go
+++ b/go/integration_test/processor/processor_test.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	_ "github.com/0xsoniclabs/tosca/go/processor/floria" // < registers floria processor for testing
+	_ "github.com/0xsoniclabs/tosca/go/processor/geth"   // < registers geth processor for testing
 	_ "github.com/0xsoniclabs/tosca/go/processor/opera"  // < registers opera processor for testing
 
 	_ "github.com/0xsoniclabs/tosca/go/interpreter/evmzero" // < registers evmzero interpreter for testing
@@ -221,6 +222,7 @@ func TestGetProcessors_ContainsMainConfigurations(t *testing.T) {
 	wanted := []string{
 		"opera/geth", "opera/lfvm", "opera/evmzero",
 		"floria/geth", "floria/lfvm", "floria/evmzero",
+		"geth-ftm/geth", "geth-ftm/lfvm", "geth-ftm/evmzero",
 	}
 	for _, n := range wanted {
 		if !slices.Contains(all, n) {

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -1,0 +1,397 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth_processor
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/0xsoniclabs/tosca/go/geth_adapter"
+	"github.com/0xsoniclabs/tosca/go/tosca"
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie/utils"
+)
+
+func init() {
+	tosca.RegisterProcessorFactory("geth-ftm", fantomProcessor)
+}
+
+func fantomProcessor(interpreter tosca.Interpreter) tosca.Processor {
+	return &Processor{
+		interpreter:        interpreter,
+		ethereumCompatible: false,
+	}
+}
+
+type Processor struct {
+	interpreter        tosca.Interpreter
+	ethereumCompatible bool
+}
+
+func (p *Processor) Run(
+	blockParameters tosca.BlockParameters,
+	transaction tosca.Transaction,
+	context tosca.TransactionContext,
+) (tosca.Receipt, error) {
+	blockContext := newBlockContext(blockParameters, context)
+	txContext := vm.TxContext{
+		Origin:     common.Address(transaction.Sender),
+		GasPrice:   transaction.GasPrice.ToBig(),
+		BlobFeeCap: blockParameters.BlobBaseFee.ToBig(),
+	}
+	stateDB := &stateDB{context: context}
+	chainConfig := blockParametersToChainConfig(blockParameters)
+	config := evmConfig(p.interpreter, p.ethereumCompatible)
+	evm := vm.NewEVM(blockContext, txContext, stateDB, chainConfig, config)
+
+	msg := transactionToMessage(transaction, blockParameters.BaseFee)
+	gasPool := new(core.GasPool).AddGas(uint64(transaction.GasLimit))
+	result, err := core.ApplyMessage(evm, msg, gasPool)
+	if err != nil {
+		if !p.ethereumCompatible && errors.Is(err, core.ErrInsufficientFunds) {
+			return tosca.Receipt{}, err
+		}
+		return tosca.Receipt{GasUsed: transaction.GasLimit}, err
+	}
+
+	createdAddress := (*tosca.Address)(&stateDB.createdContract)
+	if transaction.Recipient != nil || result.Failed() {
+		createdAddress = nil
+	}
+
+	return tosca.Receipt{
+		Success:         !result.Failed(),
+		Output:          result.ReturnData,
+		ContractAddress: createdAddress,
+		GasUsed:         tosca.Gas(result.UsedGas),
+		Logs:            stateDB.context.GetLogs(),
+	}, nil
+}
+
+func newBlockContext(blockParameters tosca.BlockParameters, context tosca.TransactionContext) vm.BlockContext {
+	canTransfer := func(stateDB vm.StateDB, address common.Address, value *uint256.Int) bool {
+		return stateDB.GetBalance(address).Cmp(value) >= 0
+	}
+
+	transfer := func(stateDB vm.StateDB, sender common.Address, recipient common.Address, value *uint256.Int) {
+		stateDB.SubBalance(sender, value, tracing.BalanceChangeTransfer)
+		stateDB.AddBalance(recipient, value, tracing.BalanceChangeTransfer)
+	}
+
+	hashFunc := func(num uint64) common.Hash {
+		return common.Hash(context.GetBlockHash(int64(num)))
+	}
+
+	return vm.BlockContext{
+		CanTransfer: canTransfer,
+		Transfer:    transfer,
+		GetHash:     hashFunc,
+		Coinbase:    common.Address(blockParameters.Coinbase),
+		GasLimit:    uint64(blockParameters.GasLimit),
+		BlockNumber: new(big.Int).SetInt64(blockParameters.BlockNumber),
+		Time:        uint64(blockParameters.Timestamp),
+		Difficulty:  big.NewInt(1),
+		BaseFee:     blockParameters.BaseFee.ToBig(),
+		BlobBaseFee: blockParameters.BlobBaseFee.ToBig(),
+		Random:      (*common.Hash)(&blockParameters.PrevRandao),
+	}
+}
+
+func blockParametersToChainConfig(blockParams tosca.BlockParameters) *params.ChainConfig {
+	chainConfig := *params.AllEthashProtocolChanges
+	chainConfig.ChainID = new(big.Int).SetBytes(blockParams.ChainID[:])
+	chainConfig.ByzantiumBlock = big.NewInt(0)
+	chainConfig.IstanbulBlock = big.NewInt(0)
+	chainConfig.BerlinBlock = big.NewInt(0)
+	chainConfig.LondonBlock = big.NewInt(0)
+	chainConfig.MergeNetsplitBlock = big.NewInt(0)
+	zeroTime := uint64(0)
+	chainConfig.ShanghaiTime = &zeroTime
+	chainConfig.CancunTime = &zeroTime
+
+	if blockParams.Revision < tosca.R13_Cancun {
+		time := uint64(blockParams.Timestamp + 1)
+		chainConfig.CancunTime = &time
+	}
+	if blockParams.Revision < tosca.R12_Shanghai {
+		time := uint64(blockParams.Timestamp + 1)
+		chainConfig.ShanghaiTime = &time
+	}
+	if blockParams.Revision < tosca.R11_Paris {
+		chainConfig.MergeNetsplitBlock = big.NewInt(blockParams.BlockNumber + 1)
+	}
+	if blockParams.Revision < tosca.R10_London {
+		chainConfig.LondonBlock = big.NewInt(blockParams.BlockNumber + 1)
+	}
+	if blockParams.Revision < tosca.R09_Berlin {
+		chainConfig.BerlinBlock = big.NewInt(blockParams.BlockNumber + 1)
+	}
+	if blockParams.Revision < tosca.R07_Istanbul {
+		chainConfig.IstanbulBlock = big.NewInt(blockParams.BlockNumber + 1)
+	}
+	return &chainConfig
+}
+
+func evmConfig(interpreter tosca.Interpreter, ethereumCompatible bool) vm.Config {
+	config := vm.Config{
+		StatePrecompiles: map[common.Address]vm.PrecompiledStateContract{
+			stateContractAddress: PreCompiledContract{},
+		},
+		Interpreter: geth_adapter.NewGethInterpreterFactory(interpreter),
+	}
+	if !ethereumCompatible {
+		config.ChargeExcessGas = true
+		config.IgnoreGasFeeCap = true
+		config.InsufficientBalanceIsNotAnError = true
+		config.SkipTipPaymentToCoinbase = true
+	}
+	return config
+}
+
+func transactionToMessage(transaction tosca.Transaction, baseFee tosca.Value) *core.Message {
+	accessList := types.AccessList{}
+	for _, tuple := range transaction.AccessList {
+		storageKeys := make([]common.Hash, len(tuple.Keys))
+		for i, key := range tuple.Keys {
+			storageKeys[i] = common.Hash(key)
+		}
+		accessList = append(accessList, types.AccessTuple{
+			Address:     common.Address(tuple.Address),
+			StorageKeys: storageKeys,
+		})
+	}
+
+	return &core.Message{
+		From:     common.Address(transaction.Sender),
+		To:       (*common.Address)(transaction.Recipient),
+		Nonce:    transaction.Nonce,
+		Value:    transaction.Value.ToBig(),
+		GasLimit: uint64(transaction.GasLimit),
+		GasPrice: transaction.GasPrice.ToBig(),
+		// gas price computation and enforcement of cap is currently performed outside of processor
+		GasFeeCap:         big.NewInt(0).Add(baseFee.ToBig(), big.NewInt(1)),
+		GasTipCap:         big.NewInt(0),
+		Data:              transaction.Input,
+		AccessList:        accessList,
+		BlobGasFeeCap:     big.NewInt(0),
+		BlobHashes:        nil,
+		SkipAccountChecks: false,
+	}
+}
+
+// stateDB is a wrapper around the tosca.TransactionContext to implement the vm.StateDB interface.
+type stateDB struct {
+	context         tosca.TransactionContext
+	refund          uint64
+	createdContract common.Address
+	refundBackups   map[tosca.Snapshot]uint64
+	beneficiary     common.Address
+}
+
+// vm.StateDB interface implementation
+
+func (s *stateDB) CreateAccount(common.Address) {
+	// not implemented
+}
+
+func (s *stateDB) CreateContract(address common.Address) {
+	s.createdContract = address
+}
+
+func (s *stateDB) SubBalance(address common.Address, value *uint256.Int, tracing tracing.BalanceChangeReason) {
+	toscaAddress := tosca.Address(address)
+	balance := s.context.GetBalance(toscaAddress)
+	s.context.SetBalance(toscaAddress, tosca.Sub(balance, tosca.ValueFromUint256(value)))
+}
+
+func (s *stateDB) AddBalance(address common.Address, value *uint256.Int, tracing tracing.BalanceChangeReason) {
+	toscaAddress := tosca.Address(address)
+	balance := s.context.GetBalance(toscaAddress)
+	s.context.SetBalance(toscaAddress, tosca.Add(balance, tosca.ValueFromUint256(value)))
+
+	// we save this address to be used as the beneficiary in a selfdestruct case.
+	s.beneficiary = address
+}
+
+func (s *stateDB) GetBalance(address common.Address) *uint256.Int {
+	return s.context.GetBalance(tosca.Address(address)).ToUint256()
+}
+
+func (s *stateDB) GetNonce(address common.Address) uint64 {
+	return s.context.GetNonce(tosca.Address(address))
+}
+
+func (s *stateDB) SetNonce(address common.Address, nonce uint64) {
+	s.context.SetNonce(tosca.Address(address), nonce)
+}
+
+func (s *stateDB) GetCodeHash(address common.Address) common.Hash {
+	return common.Hash(s.context.GetCodeHash(tosca.Address(address)))
+}
+
+func (s *stateDB) GetCode(address common.Address) []byte {
+	return s.context.GetCode(tosca.Address(address))
+}
+
+func (s *stateDB) SetCode(address common.Address, code []byte) {
+	s.context.SetCode(tosca.Address(address), code)
+}
+
+func (s *stateDB) GetCodeSize(address common.Address) int {
+	return len(s.GetCode(address))
+}
+
+func (s *stateDB) AddRefund(refund uint64) {
+	s.refund += refund
+}
+
+func (s *stateDB) SubRefund(refund uint64) {
+	s.refund -= refund
+}
+
+func (s *stateDB) GetRefund() uint64 {
+	return s.refund
+}
+
+func (s *stateDB) GetCommittedState(address common.Address, key common.Hash) common.Hash {
+	//lint:ignore SA1019 deprecated functions to be migrated
+	return common.Hash(s.context.GetCommittedStorage(tosca.Address(address), tosca.Key(key)))
+}
+
+func (s *stateDB) GetState(address common.Address, key common.Hash) common.Hash {
+	return common.Hash(s.context.GetStorage(tosca.Address(address), tosca.Key(key)))
+}
+
+func (s *stateDB) SetState(address common.Address, key common.Hash, value common.Hash) {
+	s.context.SetStorage(tosca.Address(address), tosca.Key(key), tosca.Word(value))
+}
+
+func (s *stateDB) GetStorageRoot(address common.Address) common.Hash {
+	return common.Hash{} // not implemented
+}
+
+func (s *stateDB) GetTransientState(address common.Address, key common.Hash) common.Hash {
+	return common.Hash(s.context.GetTransientStorage(tosca.Address(address), tosca.Key(key)))
+}
+
+func (s *stateDB) SetTransientState(address common.Address, key, value common.Hash) {
+	s.context.SetTransientStorage(tosca.Address(address), tosca.Key(key), tosca.Word(value))
+}
+
+func (s *stateDB) SelfDestruct(address common.Address) {
+	s.context.SelfDestruct(tosca.Address(address), tosca.Address(s.beneficiary))
+}
+
+func (s *stateDB) HasSelfDestructed(address common.Address) bool {
+	//lint:ignore SA1019 deprecated functions to be migrated
+	return s.context.HasSelfDestructed(tosca.Address(address))
+}
+
+func (s *stateDB) Selfdestruct6780(address common.Address) {
+	s.context.SelfDestruct(tosca.Address(address), tosca.Address(s.beneficiary))
+}
+
+func (s *stateDB) Exist(address common.Address) bool {
+	return s.context.AccountExists(tosca.Address(address))
+}
+
+func (s *stateDB) Empty(address common.Address) bool {
+	return s.context.GetBalance(tosca.Address(address)) == tosca.NewValue(0) &&
+		s.context.GetNonce(tosca.Address(address)) == 0 &&
+		len(s.context.GetCode(tosca.Address(address))) == 0
+}
+
+func (s *stateDB) AddressInAccessList(address common.Address) bool {
+	//lint:ignore SA1019 deprecated functions to be migrated
+	return s.context.IsAddressInAccessList(tosca.Address(address))
+}
+
+func (s *stateDB) SlotInAccessList(address common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	//lint:ignore SA1019 deprecated functions to be migrated
+	return s.context.IsSlotInAccessList(tosca.Address(address), tosca.Key(slot))
+}
+
+func (s *stateDB) AddAddressToAccessList(address common.Address) {
+	s.context.AccessAccount(tosca.Address(address))
+}
+
+func (s *stateDB) AddSlotToAccessList(address common.Address, slot common.Hash) {
+	s.context.AccessStorage(tosca.Address(address), tosca.Key(slot))
+}
+
+func (s *stateDB) PointCache() *utils.PointCache {
+	panic("not implemented")
+}
+
+func (s *stateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	if rules.IsBerlin {
+		s.context.AccessAccount(tosca.Address(sender))
+		if dest != nil {
+			s.context.AccessAccount(tosca.Address(*dest))
+		}
+		for _, addr := range precompiles {
+			s.context.AccessAccount(tosca.Address(addr))
+		}
+		for _, el := range txAccesses {
+			s.context.AccessAccount(tosca.Address(el.Address))
+			for _, key := range el.StorageKeys {
+				s.context.AccessStorage(tosca.Address(el.Address), tosca.Key(key))
+			}
+		}
+
+		if rules.IsShanghai {
+			s.context.AccessAccount(tosca.Address(coinbase))
+		}
+	}
+}
+
+func (s *stateDB) RevertToSnapshot(snapshot int) {
+	s.context.RestoreSnapshot(tosca.Snapshot(snapshot))
+	s.refund = s.refundBackups[tosca.Snapshot(snapshot)]
+}
+
+func (s *stateDB) Snapshot() int {
+	id := s.context.CreateSnapshot()
+	if s.refundBackups == nil {
+		s.refundBackups = make(map[tosca.Snapshot]uint64)
+	}
+	s.refundBackups[id] = s.refund
+	return int(id)
+}
+
+func (s *stateDB) AddLog(log *types.Log) {
+	topics := make([]tosca.Hash, len(log.Topics))
+	for i, topic := range log.Topics {
+		topics[i] = tosca.Hash(topic)
+	}
+	toscaLog := tosca.Log{
+		Address: tosca.Address(log.Address),
+		Topics:  topics,
+		Data:    log.Data,
+	}
+	s.context.EmitLog(tosca.Log(toscaLog))
+}
+
+func (s *stateDB) AddPreimage(common.Hash, []byte) {
+	panic("not implemented")
+}
+
+func (s *stateDB) Witness() *stateless.Witness {
+	return nil
+}

--- a/go/processor/geth/processor_test.go
+++ b/go/processor/geth/processor_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth_processor
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/tosca/go/tosca"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGethProcessor_RevisionConversion(t *testing.T) {
+	tests := map[string]struct {
+		blockNumber int64
+		timestamp   int64
+		revision    tosca.Revision
+	}{
+		"Istanbul": {
+			blockNumber: 1000,
+			timestamp:   0,
+			revision:    tosca.R07_Istanbul,
+		},
+		"Berlin": {
+			blockNumber: 2000,
+			timestamp:   0,
+			revision:    tosca.R09_Berlin,
+		},
+		"London": {
+			blockNumber: 3000,
+			timestamp:   0,
+			revision:    tosca.R10_London,
+		},
+		"Merge": {
+			blockNumber: 4000,
+			timestamp:   0,
+			revision:    tosca.R11_Paris,
+		},
+		"Shanghai": {
+			blockNumber: 5000,
+			timestamp:   100,
+			revision:    tosca.R12_Shanghai,
+		},
+		"Cancun": {
+			blockNumber: 6000,
+			timestamp:   200,
+			revision:    tosca.R13_Cancun,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			toscaBlockParameters := tosca.BlockParameters{
+				BlockNumber: test.blockNumber,
+				Timestamp:   test.timestamp,
+				Revision:    test.revision,
+			}
+
+			chainConfig := blockParametersToChainConfig(toscaBlockParameters)
+			rules := chainConfig.Rules(big.NewInt(test.blockNumber), test.revision >= tosca.R11_Paris, uint64(test.timestamp))
+
+			if ((test.revision >= tosca.R13_Cancun) != rules.IsCancun) ||
+				((test.revision >= tosca.R12_Shanghai) != rules.IsShanghai) ||
+				((test.revision >= tosca.R11_Paris) != rules.IsMerge) ||
+				((test.revision >= tosca.R10_London) != rules.IsLondon) ||
+				((test.revision >= tosca.R09_Berlin) != rules.IsBerlin) ||
+				((test.revision >= tosca.R07_Istanbul) != rules.IsIstanbul) {
+				t.Errorf("revision %v is not converted correctly, %v %v", test.revision, (test.revision >= tosca.R10_London), rules.IsLondon)
+			}
+		})
+	}
+}
+
+func TestGethProcessor_ConfigAddsStateContract(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	interpreter := tosca.NewMockInterpreter(ctrl)
+	config := evmConfig(interpreter, false)
+	_, ok := config.StatePrecompiles[stateContractAddress]
+	if !ok {
+		t.Errorf("state contract not added to config")
+	}
+}

--- a/go/processor/geth/processor_test.go
+++ b/go/processor/geth/processor_test.go
@@ -82,7 +82,7 @@ func TestGethProcessor_RevisionConversion(t *testing.T) {
 func TestGethProcessor_ConfigAddsStateContract(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	interpreter := tosca.NewMockInterpreter(ctrl)
-	config := evmConfig(interpreter, false)
+	config := newEVMConfig(interpreter, false)
 	_, ok := config.StatePrecompiles[stateContractAddress]
 	if !ok {
 		t.Errorf("state contract not added to config")

--- a/go/processor/geth/state_contract.go
+++ b/go/processor/geth/state_contract.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth_processor
+
+import (
+	"bytes"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+var (
+	// driverAddress is the NodeDriver contract address
+	driverAddress = common.HexToAddress("0xd100a01e00000000000000000000000000000000")
+
+	// stateContractAddress is the EvmWriter pre-compiled contract address
+	stateContractAddress = common.HexToAddress("0xd100ec0000000000000000000000000000000000")
+
+	// contractABI is the input ABI used to generate the binding from
+	contractABI string = "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"num\",\"type\":\"uint256\"}],\"name\":\"AdvanceEpochs\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"diff\",\"type\":\"bytes\"}],\"name\":\"UpdateNetworkRules\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"version\",\"type\":\"uint256\"}],\"name\":\"UpdateNetworkVersion\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"validatorID\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"pubkey\",\"type\":\"bytes\"}],\"name\":\"UpdateValidatorPubkey\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"validatorID\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"weight\",\"type\":\"uint256\"}],\"name\":\"UpdateValidatorWeight\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"backend\",\"type\":\"address\"}],\"name\":\"UpdatedBackend\",\"type\":\"event\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"_backend\",\"type\":\"address\"}],\"name\":\"setBackend\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"_backend\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_evmWriterAddress\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"acc\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"setBalance\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"acc\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"}],\"name\":\"copyCode\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"acc\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"with\",\"type\":\"address\"}],\"name\":\"swapCode\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"acc\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"key\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"value\",\"type\":\"bytes32\"}],\"name\":\"setStorage\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"acc\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"diff\",\"type\":\"uint256\"}],\"name\":\"incNonce\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"diff\",\"type\":\"bytes\"}],\"name\":\"updateNetworkRules\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"version\",\"type\":\"uint256\"}],\"name\":\"updateNetworkVersion\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"num\",\"type\":\"uint256\"}],\"name\":\"advanceEpochs\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"validatorID\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"updateValidatorWeight\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"validatorID\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"pubkey\",\"type\":\"bytes\"}],\"name\":\"updateValidatorPubkey\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"_auth\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"validatorID\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"pubkey\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"status\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"createdEpoch\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"createdTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deactivatedEpoch\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deactivatedTime\",\"type\":\"uint256\"}],\"name\":\"setGenesisValidator\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegator\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"toValidatorID\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stake\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lockedStake\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lockupFromEpoch\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lockupEndTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lockupDuration\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"earlyUnlockPenalty\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"rewards\",\"type\":\"uint256\"}],\"name\":\"setGenesisDelegation\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"validatorID\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"status\",\"type\":\"uint256\"}],\"name\":\"deactivateValidator\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"nextValidatorIDs\",\"type\":\"uint256[]\"}],\"name\":\"sealEpochValidators\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"offlineTimes\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"offlineBlocks\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"uptimes\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"originatedTxsFee\",\"type\":\"uint256[]\"}],\"name\":\"sealEpoch\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"offlineTimes\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"offlineBlocks\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"uptimes\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"originatedTxsFee\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"usedGas\",\"type\":\"uint256\"}],\"name\":\"sealEpochV1\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+)
+
+var (
+	setBalanceMethodID []byte
+	copyCodeMethodID   []byte
+	swapCodeMethodID   []byte
+	setStorageMethodID []byte
+	incNonceMethodID   []byte
+)
+
+func init() {
+	abi, err := abi.JSON(strings.NewReader(contractABI))
+	if err != nil {
+		panic(err)
+	}
+
+	for name, constID := range map[string]*[]byte{
+		"setBalance": &setBalanceMethodID,
+		"copyCode":   &copyCodeMethodID,
+		"swapCode":   &swapCodeMethodID,
+		"setStorage": &setStorageMethodID,
+		"incNonce":   &incNonceMethodID,
+	} {
+		method, exist := abi.Methods[name]
+		if !exist {
+			panic("unknown EvmWriter method")
+		}
+
+		*constID = make([]byte, len(method.ID))
+		copy(*constID, method.ID)
+	}
+}
+
+type PreCompiledContract struct{}
+
+func (PreCompiledContract) Run(stateDB vm.StateDB, _ vm.BlockContext, txCtx vm.TxContext, caller common.Address, input []byte, suppliedGas uint64) ([]byte, uint64, error) {
+	if caller != driverAddress {
+		return nil, 0, vm.ErrExecutionReverted
+	}
+	if len(input) < 4 {
+		return nil, 0, vm.ErrExecutionReverted
+	}
+	if bytes.Equal(input[:4], setBalanceMethodID) {
+		input = input[4:]
+		// setBalance
+		if suppliedGas < params.CallValueTransferGas {
+			return nil, 0, vm.ErrOutOfGas
+		}
+		suppliedGas -= params.CallValueTransferGas
+		if len(input) != 64 {
+			return nil, 0, vm.ErrExecutionReverted
+		}
+
+		acc := common.BytesToAddress(input[12:32])
+		input = input[32:]
+		value := new(uint256.Int).SetBytes32(input[:32])
+
+		if acc == txCtx.Origin {
+			// Origin balance shouldn't decrease during his transaction
+			return nil, 0, vm.ErrExecutionReverted
+		}
+
+		balance := stateDB.GetBalance(acc)
+		if balance.Cmp(value) >= 0 {
+			diff := new(uint256.Int).Sub(balance, value)
+			stateDB.SubBalance(acc, diff, tracing.BalanceChangeUnspecified)
+		} else {
+			diff := new(uint256.Int).Sub(value, balance)
+			stateDB.AddBalance(acc, diff, tracing.BalanceChangeUnspecified)
+		}
+	} else if bytes.Equal(input[:4], copyCodeMethodID) {
+		input = input[4:]
+		// copyCode
+		if suppliedGas < params.CreateGas {
+			return nil, 0, vm.ErrOutOfGas
+		}
+		suppliedGas -= params.CreateGas
+		if len(input) != 64 {
+			return nil, 0, vm.ErrExecutionReverted
+		}
+
+		accTo := common.BytesToAddress(input[12:32])
+		input = input[32:]
+		accFrom := common.BytesToAddress(input[12:32])
+
+		code := stateDB.GetCode(accFrom)
+		if code == nil {
+			code = []byte{}
+		}
+		cost := uint64(len(code)) * (params.CreateDataGas + params.MemoryGas)
+		if suppliedGas < cost {
+			return nil, 0, vm.ErrOutOfGas
+		}
+		suppliedGas -= cost
+		if accTo != accFrom {
+			stateDB.SetCode(accTo, code)
+		}
+	} else if bytes.Equal(input[:4], swapCodeMethodID) {
+		input = input[4:]
+		// swapCode
+		cost := 2 * params.CreateGas
+		if suppliedGas < cost {
+			return nil, 0, vm.ErrOutOfGas
+		}
+		suppliedGas -= cost
+		if len(input) != 64 {
+			return nil, 0, vm.ErrExecutionReverted
+		}
+
+		acc0 := common.BytesToAddress(input[12:32])
+		input = input[32:]
+		acc1 := common.BytesToAddress(input[12:32])
+		code0 := stateDB.GetCode(acc0)
+		if code0 == nil {
+			code0 = []byte{}
+		}
+		code1 := stateDB.GetCode(acc1)
+		if code1 == nil {
+			code1 = []byte{}
+		}
+		cost0 := uint64(len(code0)) * (params.CreateDataGas + params.MemoryGas)
+		cost1 := uint64(len(code1)) * (params.CreateDataGas + params.MemoryGas)
+		cost = (cost0 + cost1) / 2 // 50% discount because trie size won't increase after pruning
+		if suppliedGas < cost {
+			return nil, 0, vm.ErrOutOfGas
+		}
+		suppliedGas -= cost
+		if acc0 != acc1 {
+			stateDB.SetCode(acc0, code1)
+			stateDB.SetCode(acc1, code0)
+		}
+	} else if bytes.Equal(input[:4], setStorageMethodID) {
+		input = input[4:]
+		// setStorage
+		if suppliedGas < params.SstoreSetGasEIP2200 {
+			return nil, 0, vm.ErrOutOfGas
+		}
+		suppliedGas -= params.SstoreSetGasEIP2200
+		if len(input) != 96 {
+			return nil, 0, vm.ErrExecutionReverted
+		}
+		acc := common.BytesToAddress(input[12:32])
+		input = input[32:]
+		key := common.BytesToHash(input[:32])
+		input = input[32:]
+		value := common.BytesToHash(input[:32])
+
+		stateDB.SetState(acc, key, value)
+	} else if bytes.Equal(input[:4], incNonceMethodID) {
+		input = input[4:]
+		// incNonce
+		if suppliedGas < params.CallValueTransferGas {
+			return nil, 0, vm.ErrOutOfGas
+		}
+		suppliedGas -= params.CallValueTransferGas
+		if len(input) != 64 {
+			return nil, 0, vm.ErrExecutionReverted
+		}
+
+		acc := common.BytesToAddress(input[12:32])
+		input = input[32:]
+		value := new(big.Int).SetBytes(input[:32])
+
+		if acc == txCtx.Origin {
+			// Origin nonce shouldn't change during his transaction
+			return nil, 0, vm.ErrExecutionReverted
+		}
+
+		if value.Cmp(common.Big256) >= 0 {
+			// Don't allow large nonce increasing to prevent a nonce overflow
+			return nil, 0, vm.ErrExecutionReverted
+		}
+		if value.Sign() <= 0 {
+			return nil, 0, vm.ErrExecutionReverted
+		}
+
+		stateDB.SetNonce(acc, stateDB.GetNonce(acc)+value.Uint64())
+	} else {
+		return nil, 0, vm.ErrExecutionReverted
+	}
+	return nil, suppliedGas, nil
+}

--- a/go/processor/geth/state_contract.go
+++ b/go/processor/geth/state_contract.go
@@ -23,6 +23,9 @@ import (
 	"github.com/holiman/uint256"
 )
 
+// This file is copied from https://github.com/Fantom-foundation/Sonic/blob/main/opera/contracts/evmwriter/evm_writer.go
+// and unchanged to ensure compatibility with the code running in production.
+
 var (
 	// driverAddress is the NodeDriver contract address
 	driverAddress = common.HexToAddress("0xd100a01e00000000000000000000000000000000")


### PR DESCRIPTION
For the release of the Sonic network the processor implementation has been updated to the one from ethereum with only minor changes. To be able to test Floria against this new implementation, it is added as a processor option to tosca.

Tests to check this integration:
- [x] Tosca processor integration tests
- [x] Fantom mainnet history