### PR TITLE
Combine geth to tosca state dbs

### DIFF
--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 	"go.uber.org/mock/gomock"
-
-	_ "github.com/0xsoniclabs/tosca/go/interpreter/geth"
 )
 
 //go:generate mockgen -source adapter_test.go -destination adapter_test_mocks.go -package geth_adapter

--- a/go/geth_adapter/state_db.go
+++ b/go/geth_adapter/state_db.go
@@ -8,7 +8,7 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-package tosca_adapter
+package geth_adapter
 
 import (
 	"github.com/0xsoniclabs/tosca/go/tosca"

--- a/go/geth_adapter/state_db_test.go
+++ b/go/geth_adapter/state_db_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth_adapter
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+func TestStateDB_implementsVmStateDBInterface(t *testing.T) {
+	var _ vm.StateDB = &StateDB{}
+}

--- a/go/interpreter/geth/ct.go
+++ b/go/interpreter/geth/ct.go
@@ -18,6 +18,7 @@ import (
 	"github.com/0xsoniclabs/tosca/go/ct/st"
 	"github.com/0xsoniclabs/tosca/go/ct/utils"
 	"github.com/0xsoniclabs/tosca/go/tosca"
+	"github.com/0xsoniclabs/tosca/go/tosca_adapter"
 	geth_common "github.com/ethereum/go-ethereum/common"
 	geth_vm "github.com/ethereum/go-ethereum/core/vm"
 	"github.com/holiman/uint256"
@@ -41,7 +42,7 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 	}
 
 	evm, contract, stateDb := createGethInterpreterContext(parameters)
-	stateDb.refund = uint64(state.GasRefund)
+	stateDb.SetRefund(uint64(state.GasRefund))
 
 	evm.CallInterceptor = &callInterceptor{parameters, stateDb, state.ReadOnly}
 
@@ -141,7 +142,7 @@ func convertGethStackToCtStack(state *geth_vm.InterpreterState, stack *st.Stack)
 
 type callInterceptor struct {
 	parameters tosca.Parameters
-	stateDb    *stateDbAdapter
+	stateDb    *tosca_adapter.StateDB
 	static     bool
 }
 

--- a/go/interpreter/geth/ct.go
+++ b/go/interpreter/geth/ct.go
@@ -17,8 +17,8 @@ import (
 	"github.com/0xsoniclabs/tosca/go/ct/common"
 	"github.com/0xsoniclabs/tosca/go/ct/st"
 	"github.com/0xsoniclabs/tosca/go/ct/utils"
+	"github.com/0xsoniclabs/tosca/go/geth_adapter"
 	"github.com/0xsoniclabs/tosca/go/tosca"
-	"github.com/0xsoniclabs/tosca/go/tosca_adapter"
 	geth_common "github.com/ethereum/go-ethereum/common"
 	geth_vm "github.com/ethereum/go-ethereum/core/vm"
 	"github.com/holiman/uint256"
@@ -142,7 +142,7 @@ func convertGethStackToCtStack(state *geth_vm.InterpreterState, stack *st.Stack)
 
 type callInterceptor struct {
 	parameters tosca.Parameters
-	stateDb    *tosca_adapter.StateDB
+	stateDb    *geth_adapter.StateDB
 	static     bool
 }
 

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -16,8 +16,8 @@ import (
 	"math/big"
 
 	ct "github.com/0xsoniclabs/tosca/go/ct/common"
+	"github.com/0xsoniclabs/tosca/go/geth_adapter"
 	"github.com/0xsoniclabs/tosca/go/tosca"
-	"github.com/0xsoniclabs/tosca/go/tosca_adapter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	geth "github.com/ethereum/go-ethereum/core/vm"
@@ -133,7 +133,7 @@ func currentBlock(revision tosca.Revision) *big.Int {
 	return big.NewInt(int64(block + 2))
 }
 
-func createGethInterpreterContext(parameters tosca.Parameters) (*geth.EVM, *geth.Contract, *tosca_adapter.StateDB) {
+func createGethInterpreterContext(parameters tosca.Parameters) (*geth.EVM, *geth.Contract, *geth_adapter.StateDB) {
 	// Set hard forks for chainconfig
 	chainConfig :=
 		MakeChainConfig(*params.AllEthashProtocolChanges,
@@ -177,7 +177,7 @@ func createGethInterpreterContext(parameters tosca.Parameters) (*geth.EVM, *geth
 	// Set interpreter variant for this VM
 	config := geth.Config{}
 
-	stateDb := tosca_adapter.NewStateDB(parameters.Context)
+	stateDb := geth_adapter.NewStateDB(parameters.Context)
 	evm := geth.NewEVM(blockCtx, txCtx, stateDb, &chainConfig, config)
 
 	evm.Origin = common.Address(parameters.Origin)

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -17,14 +17,12 @@ import (
 
 	ct "github.com/0xsoniclabs/tosca/go/ct/common"
 	"github.com/0xsoniclabs/tosca/go/tosca"
+	"github.com/0xsoniclabs/tosca/go/tosca_adapter"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/tracing"
-	"github.com/ethereum/go-ethereum/core/types"
 	geth "github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/holiman/uint256"
 )
 
@@ -50,7 +48,7 @@ func (m *gethVm) Run(parameters tosca.Parameters) (tosca.Result, error) {
 	result := tosca.Result{
 		Output:    output,
 		GasLeft:   tosca.Gas(contract.Gas),
-		GasRefund: tosca.Gas(stateDb.refund),
+		GasRefund: tosca.Gas(stateDb.GetRefund()),
 		Success:   true,
 	}
 
@@ -135,7 +133,7 @@ func currentBlock(revision tosca.Revision) *big.Int {
 	return big.NewInt(int64(block + 2))
 }
 
-func createGethInterpreterContext(parameters tosca.Parameters) (*geth.EVM, *geth.Contract, *stateDbAdapter) {
+func createGethInterpreterContext(parameters tosca.Parameters) (*geth.EVM, *geth.Contract, *tosca_adapter.StateDB) {
 	// Set hard forks for chainconfig
 	chainConfig :=
 		MakeChainConfig(*params.AllEthashProtocolChanges,
@@ -179,7 +177,7 @@ func createGethInterpreterContext(parameters tosca.Parameters) (*geth.EVM, *geth
 	// Set interpreter variant for this VM
 	config := geth.Config{}
 
-	stateDb := &stateDbAdapter{context: parameters.Context}
+	stateDb := tosca_adapter.NewStateDB(parameters.Context)
 	evm := geth.NewEVM(blockCtx, txCtx, stateDb, &chainConfig, config)
 
 	evm.Origin = common.Address(parameters.Origin)
@@ -212,226 +210,4 @@ func transferFunc(stateDB geth.StateDB, callerAddress common.Address, to common.
 // canTransferFunc is the signature of a transfer function
 func canTransferFunc(stateDB geth.StateDB, callerAddress common.Address, value *uint256.Int) bool {
 	return stateDB.GetBalance(callerAddress).Cmp(value) >= 0
-}
-
-// stateDbAdapter adapts the tosca.TransactionContext interface for its usage as a geth.StateDB
-// in test environment setups. The main purpose is to facilitate unit, integration, and
-// conformance testing for the geth interpreter.
-type stateDbAdapter struct {
-	context         tosca.TransactionContext
-	refund          uint64
-	lastBeneficiary tosca.Address
-	refundBackups   map[tosca.Snapshot]uint64
-}
-
-func NewStateDbAdapter(context tosca.TransactionContext) *stateDbAdapter {
-	return &stateDbAdapter{
-		context: context,
-	}
-}
-
-func (s *stateDbAdapter) CreateAccount(common.Address) {
-	// ignored: effect not needed in test environments
-}
-
-func (s *stateDbAdapter) CreateContract(common.Address) {
-	// ignored: effect not needed in test environments
-}
-
-func (s *stateDbAdapter) SubBalance(addr common.Address, diff *uint256.Int, _ tracing.BalanceChangeReason) {
-	// Tests only running the interpreter would never call this function since balances are
-	// handled by the EVM implementation. However, Fantom's state precompile contract may
-	// conduct direct calls tho this function as part of a contract execution. Thus, it
-	// is required when running tests targeting the processor.
-	account := tosca.Address(addr)
-	cur := s.context.GetBalance(account)
-	s.context.SetBalance(account, tosca.Sub(cur, tosca.ValueFromUint256(diff)))
-}
-
-func (s *stateDbAdapter) AddBalance(addr common.Address, diff *uint256.Int, _ tracing.BalanceChangeReason) {
-	// Tests only running the interpreter would never call this function since balances are
-	// handled by the EVM implementation. However, Fantom's state precompile contract may
-	// conduct direct calls tho this function as part of a contract execution. Thus, it
-	// is required when running tests targeting the processor.
-	account := tosca.Address(addr)
-	cur := s.context.GetBalance(account)
-	s.context.SetBalance(account, tosca.Add(cur, tosca.ValueFromUint256(diff)))
-
-	// we save this address to be used as the beneficiary in a selfdestruct case.
-	s.lastBeneficiary = tosca.Address(addr)
-}
-
-func (s *stateDbAdapter) GetBalance(addr common.Address) *uint256.Int {
-	value := s.context.GetBalance(tosca.Address(addr))
-	return value.ToUint256()
-}
-
-func (s *stateDbAdapter) GetNonce(addr common.Address) uint64 {
-	return s.context.GetNonce(tosca.Address(addr))
-}
-
-func (s *stateDbAdapter) SetNonce(addr common.Address, nonce uint64) {
-	s.context.SetNonce(tosca.Address(addr), nonce)
-}
-
-func (s *stateDbAdapter) GetCodeHash(addr common.Address) common.Hash {
-	return common.Hash(s.context.GetCodeHash(tosca.Address(addr)))
-}
-
-func (s *stateDbAdapter) GetCode(addr common.Address) []byte {
-	return s.context.GetCode(tosca.Address(addr))
-}
-
-func (s *stateDbAdapter) SetCode(addr common.Address, code []byte) {
-	s.context.SetCode(tosca.Address(addr), code)
-}
-
-func (s *stateDbAdapter) GetCodeSize(addr common.Address) int {
-	return s.context.GetCodeSize(tosca.Address(addr))
-}
-
-func (s *stateDbAdapter) AddRefund(value uint64) {
-	s.refund += value
-}
-
-func (s *stateDbAdapter) SubRefund(value uint64) {
-	s.refund -= value
-}
-
-func (s *stateDbAdapter) GetRefund() uint64 {
-	return s.refund
-}
-
-func (s *stateDbAdapter) GetCommittedState(addr common.Address, key common.Hash) common.Hash {
-	//lint:ignore SA1019 deprecated functions to be migrated in #616
-	return common.Hash(s.context.GetCommittedStorage(tosca.Address(addr), tosca.Key(key)))
-}
-
-func (s *stateDbAdapter) GetState(addr common.Address, key common.Hash) common.Hash {
-	return common.Hash(s.context.GetStorage(tosca.Address(addr), tosca.Key(key)))
-}
-
-func (s *stateDbAdapter) SetState(addr common.Address, key common.Hash, value common.Hash) {
-	s.context.SetStorage(tosca.Address(addr), tosca.Key(key), tosca.Word(value))
-}
-
-func (s *stateDbAdapter) GetStorageRoot(addr common.Address) common.Hash {
-	// ignored: effect not needed in test environments
-	return common.Hash{}
-}
-
-func (s *stateDbAdapter) GetTransientState(addr common.Address, key common.Hash) common.Hash {
-	return common.Hash(s.context.GetTransientStorage(tosca.Address(addr), tosca.Key(key)))
-}
-
-func (s *stateDbAdapter) SetTransientState(addr common.Address, key, value common.Hash) {
-	s.context.SetTransientStorage(tosca.Address(addr), tosca.Key(key), tosca.Word(value))
-}
-
-func (s *stateDbAdapter) SelfDestruct(addr common.Address) {
-	s.context.SelfDestruct(tosca.Address(addr), s.lastBeneficiary)
-}
-
-func (s *stateDbAdapter) HasSelfDestructed(addr common.Address) bool {
-	//lint:ignore SA1019 deprecated functions to be migrated in #616
-	return s.context.HasSelfDestructed(tosca.Address(addr))
-}
-
-func (s *stateDbAdapter) Selfdestruct6780(addr common.Address) {
-	s.context.SelfDestruct(tosca.Address(addr), s.lastBeneficiary)
-}
-
-func (s *stateDbAdapter) Exist(addr common.Address) bool {
-	return s.context.AccountExists(tosca.Address(addr))
-}
-
-func (s *stateDbAdapter) Empty(addr common.Address) bool {
-	return s.GetBalance(addr).IsZero() && s.GetNonce(addr) == 0 && s.GetCodeSize(addr) == 0
-}
-
-func (s *stateDbAdapter) PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	s.context.AccessAccount(tosca.Address(sender))
-	if dest != nil {
-		s.context.AccessAccount(tosca.Address(*dest))
-	}
-	for _, addr := range precompiles {
-		s.context.AccessAccount(tosca.Address(addr))
-	}
-	for _, el := range txAccesses {
-		s.context.AccessAccount(tosca.Address(el.Address))
-		for _, key := range el.StorageKeys {
-			s.context.AccessStorage(tosca.Address(el.Address), tosca.Key(key))
-		}
-	}
-}
-
-func (s *stateDbAdapter) AddressInAccessList(addr common.Address) bool {
-	//lint:ignore SA1019 deprecated functions to be migrated in #616
-	return s.context.IsAddressInAccessList(tosca.Address(addr))
-}
-
-func (s *stateDbAdapter) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
-	//lint:ignore SA1019 deprecated functions to be migrated in #616
-	return s.context.IsSlotInAccessList(tosca.Address(addr), tosca.Key(slot))
-}
-
-func (s *stateDbAdapter) AddAddressToAccessList(addr common.Address) {
-	s.context.AccessAccount(tosca.Address(addr))
-}
-
-func (s *stateDbAdapter) AddSlotToAccessList(addr common.Address, slot common.Hash) {
-	s.context.AccessStorage(tosca.Address(addr), tosca.Key(slot))
-}
-
-func (s *stateDbAdapter) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	// ignored: effect not needed in test environments
-	panic("not implemented")
-}
-
-func (s *stateDbAdapter) RevertToSnapshot(snapshot int) {
-	s.context.RestoreSnapshot(tosca.Snapshot(snapshot))
-	s.refund = s.refundBackups[tosca.Snapshot(snapshot)]
-}
-
-func (s *stateDbAdapter) Snapshot() int {
-	id := s.context.CreateSnapshot()
-	if s.refundBackups == nil {
-		s.refundBackups = make(map[tosca.Snapshot]uint64)
-	}
-	s.refundBackups[id] = s.refund
-	return int(id)
-}
-
-func (s *stateDbAdapter) AddLog(log *types.Log) {
-	topics := make([]tosca.Hash, 0, len(log.Topics))
-	for _, cur := range log.Topics {
-		topics = append(topics, tosca.Hash(cur))
-	}
-	s.context.EmitLog(tosca.Log{
-		Address: tosca.Address(log.Address),
-		Topics:  topics,
-		Data:    log.Data,
-	})
-}
-
-func (s *stateDbAdapter) GetLogs() []tosca.Log {
-	return s.context.GetLogs()
-}
-
-func (s *stateDbAdapter) AddPreimage(common.Hash, []byte) {
-	panic("should not be needed in test environments")
-}
-
-func (s *stateDbAdapter) ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error {
-	panic("should not be needed in test environments")
-}
-
-func (s *stateDbAdapter) PointCache() *utils.PointCache {
-	// see https://eips.ethereum.org/EIPS/eip-4762
-	panic("should not be needed by revisions up to Cancun")
-}
-
-func (s *stateDbAdapter) Witness() *stateless.Witness {
-	// this should not be relevant for revisions up to Cancun
-	return nil
 }

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/0xsoniclabs/tosca/go/geth_adapter"
 	"github.com/0xsoniclabs/tosca/go/tosca"
-	"github.com/0xsoniclabs/tosca/go/tosca_adapter"
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -54,7 +53,7 @@ func (p *Processor) Run(
 		GasPrice:   transaction.GasPrice.ToBig(),
 		BlobFeeCap: blockParameters.BlobBaseFee.ToBig(),
 	}
-	stateDB := tosca_adapter.NewStateDB(context)
+	stateDB := geth_adapter.NewStateDB(context)
 	chainConfig := blockParametersToChainConfig(blockParameters)
 	config := newEVMConfig(p.interpreter, p.ethereumCompatible)
 	evm := vm.NewEVM(blockContext, txContext, stateDB, chainConfig, config)

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -16,23 +16,22 @@ import (
 
 	"github.com/0xsoniclabs/tosca/go/geth_adapter"
 	"github.com/0xsoniclabs/tosca/go/tosca"
+	"github.com/0xsoniclabs/tosca/go/tosca_adapter"
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/trie/utils"
 )
 
 func init() {
-	tosca.RegisterProcessorFactory("geth-sonic", fantomProcessor)
+	tosca.RegisterProcessorFactory("geth-sonic", sonicProcessor)
 }
 
-func fantomProcessor(interpreter tosca.Interpreter) tosca.Processor {
+func sonicProcessor(interpreter tosca.Interpreter) tosca.Processor {
 	return &Processor{
 		interpreter:        interpreter,
 		ethereumCompatible: false,
@@ -55,7 +54,7 @@ func (p *Processor) Run(
 		GasPrice:   transaction.GasPrice.ToBig(),
 		BlobFeeCap: blockParameters.BlobBaseFee.ToBig(),
 	}
-	stateDB := &stateDB{context: context}
+	stateDB := tosca_adapter.NewStateDB(context)
 	chainConfig := blockParametersToChainConfig(blockParameters)
 	config := newEVMConfig(p.interpreter, p.ethereumCompatible)
 	evm := vm.NewEVM(blockContext, txContext, stateDB, chainConfig, config)
@@ -70,9 +69,22 @@ func (p *Processor) Run(
 		return tosca.Receipt{GasUsed: transaction.GasLimit}, err
 	}
 
-	createdAddress := (*tosca.Address)(&stateDB.createdContract)
+	createdAddress := (*tosca.Address)(stateDB.GetCreatedContract())
 	if transaction.Recipient != nil || result.Failed() {
 		createdAddress = nil
+	}
+
+	logs := make([]tosca.Log, 0)
+	for _, log := range stateDB.GetLogs() {
+		topics := make([]tosca.Hash, len(log.Topics))
+		for i, topic := range log.Topics {
+			topics[i] = tosca.Hash(topic)
+		}
+		logs = append(logs, tosca.Log{
+			Address: tosca.Address(log.Address),
+			Topics:  topics,
+			Data:    log.Data,
+		})
 	}
 
 	return tosca.Receipt{
@@ -80,7 +92,7 @@ func (p *Processor) Run(
 		Output:          result.ReturnData,
 		ContractAddress: createdAddress,
 		GasUsed:         tosca.Gas(result.UsedGas),
-		Logs:            stateDB.context.GetLogs(),
+		Logs:            logs,
 	}, nil
 }
 
@@ -195,211 +207,4 @@ func transactionToMessage(transaction tosca.Transaction, baseFee tosca.Value) *c
 		BlobHashes:        nil,
 		SkipAccountChecks: false,
 	}
-}
-
-// stateDB is a wrapper around the tosca.TransactionContext to implement the vm.StateDB interface.
-// TODO: merge with tosca/go/interpreter/geth/geth.go stateDbAdapter
-type stateDB struct {
-	context         tosca.TransactionContext
-	refund          uint64
-	createdContract common.Address
-	refundBackups   map[tosca.Snapshot]uint64
-	beneficiary     common.Address
-}
-
-// vm.StateDB interface implementation
-
-func (s *stateDB) CreateAccount(common.Address) {
-	// not implemented
-}
-
-func (s *stateDB) CreateContract(address common.Address) {
-	s.createdContract = address
-}
-
-func (s *stateDB) SubBalance(address common.Address, value *uint256.Int, tracing tracing.BalanceChangeReason) {
-	toscaAddress := tosca.Address(address)
-	balance := s.context.GetBalance(toscaAddress)
-	s.context.SetBalance(toscaAddress, tosca.Sub(balance, tosca.ValueFromUint256(value)))
-}
-
-func (s *stateDB) AddBalance(address common.Address, value *uint256.Int, tracing tracing.BalanceChangeReason) {
-	toscaAddress := tosca.Address(address)
-	balance := s.context.GetBalance(toscaAddress)
-	s.context.SetBalance(toscaAddress, tosca.Add(balance, tosca.ValueFromUint256(value)))
-
-	// In the case of a seldestruct the balance is transferred to the beneficiary,
-	// we save this address for the context-selfdestruct call.
-	// this only works if the balance transfer is performed before the selfdestruct call,
-	// as it is the performed in geth and the geth adapter.
-	s.beneficiary = address
-}
-
-func (s *stateDB) GetBalance(address common.Address) *uint256.Int {
-	return s.context.GetBalance(tosca.Address(address)).ToUint256()
-}
-
-func (s *stateDB) GetNonce(address common.Address) uint64 {
-	return s.context.GetNonce(tosca.Address(address))
-}
-
-func (s *stateDB) SetNonce(address common.Address, nonce uint64) {
-	s.context.SetNonce(tosca.Address(address), nonce)
-}
-
-func (s *stateDB) GetCodeHash(address common.Address) common.Hash {
-	return common.Hash(s.context.GetCodeHash(tosca.Address(address)))
-}
-
-func (s *stateDB) GetCode(address common.Address) []byte {
-	return s.context.GetCode(tosca.Address(address))
-}
-
-func (s *stateDB) SetCode(address common.Address, code []byte) {
-	s.context.SetCode(tosca.Address(address), code)
-}
-
-func (s *stateDB) GetCodeSize(address common.Address) int {
-	return len(s.GetCode(address))
-}
-
-func (s *stateDB) AddRefund(refund uint64) {
-	s.refund += refund
-}
-
-func (s *stateDB) SubRefund(refund uint64) {
-	s.refund -= refund
-}
-
-func (s *stateDB) GetRefund() uint64 {
-	return s.refund
-}
-
-func (s *stateDB) GetCommittedState(address common.Address, key common.Hash) common.Hash {
-	//lint:ignore SA1019 deprecated functions to be migrated
-	return common.Hash(s.context.GetCommittedStorage(tosca.Address(address), tosca.Key(key)))
-}
-
-func (s *stateDB) GetState(address common.Address, key common.Hash) common.Hash {
-	return common.Hash(s.context.GetStorage(tosca.Address(address), tosca.Key(key)))
-}
-
-func (s *stateDB) SetState(address common.Address, key common.Hash, value common.Hash) {
-	s.context.SetStorage(tosca.Address(address), tosca.Key(key), tosca.Word(value))
-}
-
-func (s *stateDB) GetStorageRoot(address common.Address) common.Hash {
-	return common.Hash{} // not implemented
-}
-
-func (s *stateDB) GetTransientState(address common.Address, key common.Hash) common.Hash {
-	return common.Hash(s.context.GetTransientStorage(tosca.Address(address), tosca.Key(key)))
-}
-
-func (s *stateDB) SetTransientState(address common.Address, key, value common.Hash) {
-	s.context.SetTransientStorage(tosca.Address(address), tosca.Key(key), tosca.Word(value))
-}
-
-func (s *stateDB) SelfDestruct(address common.Address) {
-	s.context.SelfDestruct(tosca.Address(address), tosca.Address(s.beneficiary))
-}
-
-func (s *stateDB) HasSelfDestructed(address common.Address) bool {
-	//lint:ignore SA1019 deprecated functions to be migrated
-	return s.context.HasSelfDestructed(tosca.Address(address))
-}
-
-func (s *stateDB) Selfdestruct6780(address common.Address) {
-	s.context.SelfDestruct(tosca.Address(address), tosca.Address(s.beneficiary))
-}
-
-func (s *stateDB) Exist(address common.Address) bool {
-	return s.context.AccountExists(tosca.Address(address))
-}
-
-func (s *stateDB) Empty(address common.Address) bool {
-	return s.context.GetBalance(tosca.Address(address)) == tosca.NewValue(0) &&
-		s.context.GetNonce(tosca.Address(address)) == 0 &&
-		len(s.context.GetCode(tosca.Address(address))) == 0
-}
-
-func (s *stateDB) AddressInAccessList(address common.Address) bool {
-	// using the non-deprecated function has a side effect of adding the address to the access list
-	return bool(s.context.AccessAccount(tosca.Address(address)))
-}
-
-func (s *stateDB) SlotInAccessList(address common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
-	// using the non-deprecated functions has a side effect of adding the address and slot to the access list
-	addressOk = bool(s.context.AccessAccount(tosca.Address(address)))
-	slotOk = bool(s.context.AccessStorage(tosca.Address(address), tosca.Key(slot)))
-	return addressOk, slotOk
-}
-
-func (s *stateDB) AddAddressToAccessList(address common.Address) {
-	s.context.AccessAccount(tosca.Address(address))
-}
-
-func (s *stateDB) AddSlotToAccessList(address common.Address, slot common.Hash) {
-	s.context.AccessStorage(tosca.Address(address), tosca.Key(slot))
-}
-
-func (s *stateDB) PointCache() *utils.PointCache {
-	panic("not implemented")
-}
-
-func (s *stateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	if rules.IsBerlin {
-		s.context.AccessAccount(tosca.Address(sender))
-		if dest != nil {
-			s.context.AccessAccount(tosca.Address(*dest))
-		}
-		for _, addr := range precompiles {
-			s.context.AccessAccount(tosca.Address(addr))
-		}
-		for _, el := range txAccesses {
-			s.context.AccessAccount(tosca.Address(el.Address))
-			for _, key := range el.StorageKeys {
-				s.context.AccessStorage(tosca.Address(el.Address), tosca.Key(key))
-			}
-		}
-
-		if rules.IsShanghai {
-			s.context.AccessAccount(tosca.Address(coinbase))
-		}
-	}
-}
-
-func (s *stateDB) RevertToSnapshot(snapshot int) {
-	s.context.RestoreSnapshot(tosca.Snapshot(snapshot))
-	s.refund = s.refundBackups[tosca.Snapshot(snapshot)]
-}
-
-func (s *stateDB) Snapshot() int {
-	id := s.context.CreateSnapshot()
-	if s.refundBackups == nil {
-		s.refundBackups = make(map[tosca.Snapshot]uint64)
-	}
-	s.refundBackups[id] = s.refund
-	return int(id)
-}
-
-func (s *stateDB) AddLog(log *types.Log) {
-	topics := make([]tosca.Hash, len(log.Topics))
-	for i, topic := range log.Topics {
-		topics[i] = tosca.Hash(topic)
-	}
-	toscaLog := tosca.Log{
-		Address: tosca.Address(log.Address),
-		Topics:  topics,
-		Data:    log.Data,
-	}
-	s.context.EmitLog(tosca.Log(toscaLog))
-}
-
-func (s *stateDB) AddPreimage(common.Hash, []byte) {
-	panic("not implemented")
-}
-
-func (s *stateDB) Witness() *stateless.Witness {
-	return nil
 }

--- a/go/processor/opera/processor.go
+++ b/go/processor/opera/processor.go
@@ -26,10 +26,10 @@ import (
 	"github.com/0xsoniclabs/tosca/go/geth_adapter"
 	geth_interpreter "github.com/0xsoniclabs/tosca/go/interpreter/geth"
 	"github.com/0xsoniclabs/tosca/go/tosca"
+	"github.com/0xsoniclabs/tosca/go/tosca_adapter"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
-	"github.com/ethereum/go-ethereum/core/types"
 	geth "github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
@@ -153,7 +153,7 @@ func (p *processor) Run(
 		chainConfig.IstanbulBlock = big.NewInt(blockParams.BlockNumber + 1)
 	}
 
-	stateDb := geth_interpreter.NewStateDbAdapter(context)
+	stateDb := tosca_adapter.NewStateDB(context)
 	evm := geth.NewEVM(blockCtx, txCtx, stateDb, &chainConfig, config)
 
 	// -- start of execution --
@@ -204,24 +204,21 @@ func (p *processor) Run(
 		// London uses the same list as Berlin, Cancun extends it.
 		precompiledContracts := geth.PrecompiledAddressesBerlin
 
-		var accessList types.AccessList
-		for _, tuple := range transaction.AccessList {
-			keys := make([]common.Hash, len(tuple.Keys))
-			for i, key := range tuple.Keys {
-				keys[i] = common.Hash(key)
-			}
-			accessList = append(accessList, types.AccessTuple{
-				Address:     common.Address(tuple.Address),
-				StorageKeys: keys,
-			})
+		stateDb.AddAddressToAccessList(common.Address(transaction.Sender))
+		if dest != nil {
+			stateDb.AddAddressToAccessList(common.Address(*dest))
 		}
 
-		stateDb.PrepareAccessList(
-			common.Address(transaction.Sender),
-			dest,
-			precompiledContracts,
-			accessList,
-		)
+		for _, addr := range precompiledContracts {
+			stateDb.AddAddressToAccessList(common.Address(addr))
+		}
+
+		for _, tuple := range transaction.AccessList {
+			stateDb.AddAddressToAccessList(common.Address(tuple.Address))
+			for _, key := range tuple.Keys {
+				stateDb.AddSlotToAccessList(common.Address(tuple.Address), common.Hash(key))
+			}
+		}
 	}
 
 	var (

--- a/go/processor/opera/processor.go
+++ b/go/processor/opera/processor.go
@@ -26,7 +26,6 @@ import (
 	"github.com/0xsoniclabs/tosca/go/geth_adapter"
 	geth_interpreter "github.com/0xsoniclabs/tosca/go/interpreter/geth"
 	"github.com/0xsoniclabs/tosca/go/tosca"
-	"github.com/0xsoniclabs/tosca/go/tosca_adapter"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -153,7 +152,7 @@ func (p *processor) Run(
 		chainConfig.IstanbulBlock = big.NewInt(blockParams.BlockNumber + 1)
 	}
 
-	stateDb := tosca_adapter.NewStateDB(context)
+	stateDb := geth_adapter.NewStateDB(context)
 	evm := geth.NewEVM(blockCtx, txCtx, stateDb, &chainConfig, config)
 
 	// -- start of execution --

--- a/go/tosca_adapter/state_db.go
+++ b/go/tosca_adapter/state_db.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package tosca_adapter
+
+import (
+	"github.com/0xsoniclabs/tosca/go/tosca"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie/utils"
+	"github.com/holiman/uint256"
+)
+
+// StateDB is a wrapper around the tosca.TransactionContext to implement the vm.StateDB interface.
+type StateDB struct {
+	context         tosca.TransactionContext
+	createdContract *common.Address
+	refund          uint64
+	refundBackups   map[tosca.Snapshot]uint64
+	beneficiary     common.Address
+}
+
+func NewStateDB(ctx tosca.TransactionContext) *StateDB {
+	return &StateDB{context: ctx}
+}
+
+func (s *StateDB) GetCreatedContract() *common.Address {
+	return s.createdContract
+}
+
+func (s *StateDB) SetRefund(refund uint64) {
+	s.refund = refund
+}
+
+func (s *StateDB) GetLogs() []types.Log {
+	logs := make([]types.Log, 0)
+	for _, log := range s.context.GetLogs() {
+		topics := make([]common.Hash, len(log.Topics))
+		for i, topic := range log.Topics {
+			topics[i] = common.Hash(topic)
+		}
+		logs = append(logs, types.Log{
+			Address: common.Address(log.Address),
+			Topics:  topics,
+			Data:    log.Data,
+		})
+	}
+	return logs
+}
+
+// vm.StateDB interface implementation
+
+func (s *StateDB) CreateAccount(common.Address) {
+	// not implemented
+}
+
+func (s *StateDB) CreateContract(address common.Address) {
+	s.createdContract = &address
+}
+
+func (s *StateDB) SubBalance(address common.Address, value *uint256.Int, tracing tracing.BalanceChangeReason) {
+	toscaAddress := tosca.Address(address)
+	balance := s.context.GetBalance(toscaAddress)
+	s.context.SetBalance(toscaAddress, tosca.Sub(balance, tosca.ValueFromUint256(value)))
+}
+
+func (s *StateDB) AddBalance(address common.Address, value *uint256.Int, tracing tracing.BalanceChangeReason) {
+	toscaAddress := tosca.Address(address)
+	balance := s.context.GetBalance(toscaAddress)
+	s.context.SetBalance(toscaAddress, tosca.Add(balance, tosca.ValueFromUint256(value)))
+
+	// In the case of a seldestruct the balance is transferred to the beneficiary,
+	// we save this address for the context-selfdestruct call.
+	// this only works if the balance transfer is performed before the selfdestruct call,
+	// as it is the performed in geth and the geth adapter.
+	s.beneficiary = address
+}
+
+func (s *StateDB) GetBalance(address common.Address) *uint256.Int {
+	return s.context.GetBalance(tosca.Address(address)).ToUint256()
+}
+
+func (s *StateDB) GetNonce(address common.Address) uint64 {
+	return s.context.GetNonce(tosca.Address(address))
+}
+
+func (s *StateDB) SetNonce(address common.Address, nonce uint64) {
+	s.context.SetNonce(tosca.Address(address), nonce)
+}
+
+func (s *StateDB) GetCodeHash(address common.Address) common.Hash {
+	return common.Hash(s.context.GetCodeHash(tosca.Address(address)))
+}
+
+func (s *StateDB) GetCode(address common.Address) []byte {
+	return s.context.GetCode(tosca.Address(address))
+}
+
+func (s *StateDB) SetCode(address common.Address, code []byte) {
+	s.context.SetCode(tosca.Address(address), code)
+}
+
+func (s *StateDB) GetCodeSize(address common.Address) int {
+	return s.context.GetCodeSize(tosca.Address(address))
+}
+
+func (s *StateDB) AddRefund(refund uint64) {
+	s.refund += refund
+}
+
+func (s *StateDB) SubRefund(refund uint64) {
+	s.refund -= refund
+}
+
+func (s *StateDB) GetRefund() uint64 {
+	return s.refund
+}
+
+func (s *StateDB) GetCommittedState(address common.Address, key common.Hash) common.Hash {
+	//lint:ignore SA1019 deprecated functions to be migrated
+	return common.Hash(s.context.GetCommittedStorage(tosca.Address(address), tosca.Key(key)))
+}
+
+func (s *StateDB) GetState(address common.Address, key common.Hash) common.Hash {
+	return common.Hash(s.context.GetStorage(tosca.Address(address), tosca.Key(key)))
+}
+
+func (s *StateDB) SetState(address common.Address, key common.Hash, value common.Hash) {
+	s.context.SetStorage(tosca.Address(address), tosca.Key(key), tosca.Word(value))
+}
+
+func (s *StateDB) GetStorageRoot(address common.Address) common.Hash {
+	return common.Hash{} // not implemented
+}
+
+func (s *StateDB) GetTransientState(address common.Address, key common.Hash) common.Hash {
+	return common.Hash(s.context.GetTransientStorage(tosca.Address(address), tosca.Key(key)))
+}
+
+func (s *StateDB) SetTransientState(address common.Address, key, value common.Hash) {
+	s.context.SetTransientStorage(tosca.Address(address), tosca.Key(key), tosca.Word(value))
+}
+
+func (s *StateDB) SelfDestruct(address common.Address) {
+	s.context.SelfDestruct(tosca.Address(address), tosca.Address(s.beneficiary))
+}
+
+func (s *StateDB) HasSelfDestructed(address common.Address) bool {
+	//lint:ignore SA1019 deprecated functions to be migrated
+	return s.context.HasSelfDestructed(tosca.Address(address))
+}
+
+func (s *StateDB) Selfdestruct6780(address common.Address) {
+	s.context.SelfDestruct(tosca.Address(address), tosca.Address(s.beneficiary))
+}
+
+func (s *StateDB) Exist(address common.Address) bool {
+	return s.context.AccountExists(tosca.Address(address))
+}
+
+func (s *StateDB) Empty(address common.Address) bool {
+	return s.context.GetBalance(tosca.Address(address)) == tosca.NewValue(0) &&
+		s.context.GetNonce(tosca.Address(address)) == 0 &&
+		s.context.GetCodeSize(tosca.Address(address)) == 0
+}
+
+func (s *StateDB) AddressInAccessList(address common.Address) bool {
+	//lint:ignore SA1019 deprecated functions to be migrated
+	return s.context.IsAddressInAccessList(tosca.Address(address))
+}
+
+func (s *StateDB) SlotInAccessList(address common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	//lint:ignore SA1019 deprecated functions to be migrated
+	return s.context.IsSlotInAccessList(tosca.Address(address), tosca.Key(slot))
+}
+
+func (s *StateDB) AddAddressToAccessList(address common.Address) {
+	s.context.AccessAccount(tosca.Address(address))
+}
+
+func (s *StateDB) AddSlotToAccessList(address common.Address, slot common.Hash) {
+	s.context.AccessStorage(tosca.Address(address), tosca.Key(slot))
+}
+
+func (s *StateDB) PointCache() *utils.PointCache {
+	panic("not implemented")
+}
+
+func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	if rules.IsBerlin {
+		s.context.AccessAccount(tosca.Address(sender))
+		if dest != nil {
+			s.context.AccessAccount(tosca.Address(*dest))
+		}
+		for _, addr := range precompiles {
+			s.context.AccessAccount(tosca.Address(addr))
+		}
+		for _, el := range txAccesses {
+			s.context.AccessAccount(tosca.Address(el.Address))
+			for _, key := range el.StorageKeys {
+				s.context.AccessStorage(tosca.Address(el.Address), tosca.Key(key))
+			}
+		}
+
+		if rules.IsShanghai {
+			s.context.AccessAccount(tosca.Address(coinbase))
+		}
+	}
+}
+
+func (s *StateDB) RevertToSnapshot(snapshot int) {
+	s.context.RestoreSnapshot(tosca.Snapshot(snapshot))
+	s.refund = s.refundBackups[tosca.Snapshot(snapshot)]
+}
+
+func (s *StateDB) Snapshot() int {
+	id := s.context.CreateSnapshot()
+	if s.refundBackups == nil {
+		s.refundBackups = make(map[tosca.Snapshot]uint64)
+	}
+	s.refundBackups[id] = s.refund
+	return int(id)
+}
+
+func (s *StateDB) AddLog(log *types.Log) {
+	topics := make([]tosca.Hash, len(log.Topics))
+	for i, topic := range log.Topics {
+		topics[i] = tosca.Hash(topic)
+	}
+	toscaLog := tosca.Log{
+		Address: tosca.Address(log.Address),
+		Topics:  topics,
+		Data:    log.Data,
+	}
+	s.context.EmitLog(tosca.Log(toscaLog))
+}
+
+func (s *StateDB) AddPreimage(common.Hash, []byte) {
+	panic("not implemented")
+}
+
+func (s *StateDB) Witness() *stateless.Witness {
+	return nil
+}


### PR DESCRIPTION
The state db used for the geth-interpreter and geth-processor are identical, this PR merges them into a single file.