### PR TITLE
Extend transaction context

### DIFF
--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -216,7 +216,7 @@ func (c *ctRunContext) CreateAccount(tosca.Address) {
 	panic("should not be needed")
 }
 
-func (c *ctRunContext) HasEmptyStateRoot(tosca.Address) bool {
+func (c *ctRunContext) HasEmptyStorage(tosca.Address) bool {
 	panic("should not be needed")
 }
 

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -212,7 +212,11 @@ func (c *ctRunContext) GetNonce(tosca.Address) uint64 {
 
 // --- API only needed in the context of a full transaction, which is not covered by CT ---
 
-func (c *ctRunContext) CreateAccount(tosca.Address, tosca.Code) bool {
+func (c *ctRunContext) CreateAccount(tosca.Address) {
+	panic("should not be needed")
+}
+
+func (c *ctRunContext) HasEmptyStateRoot(tosca.Address) bool {
 	panic("should not be needed")
 }
 

--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -427,13 +427,9 @@ func (a *runContextAdapter) CreateAccount(addr tosca.Address) {
 	a.evm.StateDB.CreateContract(gc.Address(addr))
 }
 
-func (a *runContextAdapter) HasEmptyStateRoot(addr tosca.Address) bool {
-	codeHash := a.evm.StateDB.GetCodeHash(gc.Address(addr))
+func (a *runContextAdapter) HasEmptyStorage(addr tosca.Address) bool {
 	rootHash := a.evm.StateDB.GetStorageRoot(gc.Address(addr))
-
-	return a.evm.StateDB.GetNonce(gc.Address(addr)) == 0 &&
-		(codeHash == gc.Hash{} || codeHash == types.EmptyCodeHash) &&
-		(rootHash == gc.Hash{} || rootHash == types.EmptyRootHash)
+	return rootHash == gc.Hash{} || rootHash == types.EmptyRootHash
 }
 
 func (a *runContextAdapter) AccountExists(addr tosca.Address) bool {

--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -428,6 +428,7 @@ func (a *runContextAdapter) CreateAccount(addr tosca.Address) {
 }
 
 func (a *runContextAdapter) HasEmptyStorage(addr tosca.Address) bool {
+	// The storage is empty if the root is the empty or zero hash.
 	rootHash := a.evm.StateDB.GetStorageRoot(gc.Address(addr))
 	return rootHash == gc.Hash{} || rootHash == types.EmptyRootHash
 }

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -261,7 +261,6 @@ func TestRunContextAdapter_AccountOperations(t *testing.T) {
 	adapter := &runContextAdapter{evm: &geth.EVM{StateDB: stateDb}}
 
 	address := tosca.Address{0x42}
-	code := tosca.Code{1, 2, 3}
 
 	stateDb.EXPECT().AddressInAccessList(gc.Address(address)).Return(false)
 	stateDb.EXPECT().AddAddressToAccessList(gc.Address(address))
@@ -278,8 +277,10 @@ func TestRunContextAdapter_AccountOperations(t *testing.T) {
 
 	stateDb.EXPECT().Exist(gc.Address(address)).Return(false)
 	stateDb.EXPECT().CreateAccount(gc.Address(address))
-	stateDb.EXPECT().SetCode(gc.Address(address), code)
-	created := adapter.CreateAccount(address, code)
+	stateDb.EXPECT().CreateContract(gc.Address(address))
+	stateDb.EXPECT().Exist(gc.Address(address)).Return(true)
+	adapter.CreateAccount(address)
+	created := adapter.AccountExists(address)
 	if !created {
 		t.Errorf("Account should have been created")
 	}

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -275,15 +275,11 @@ func TestRunContextAdapter_AccountOperations(t *testing.T) {
 		t.Errorf("Account should exist")
 	}
 
+	// Ensure that both CreateAccount and CreateContract are called when the account does not exist
 	stateDb.EXPECT().Exist(gc.Address(address)).Return(false)
 	stateDb.EXPECT().CreateAccount(gc.Address(address))
 	stateDb.EXPECT().CreateContract(gc.Address(address))
-	stateDb.EXPECT().Exist(gc.Address(address)).Return(true)
 	adapter.CreateAccount(address)
-	created := adapter.AccountExists(address)
-	if !created {
-		t.Errorf("Account should have been created")
-	}
 
 	stateDb.EXPECT().AddressInAccessList(gc.Address(address)).Return(true)
 	inAccessList := adapter.IsAddressInAccessList(address)

--- a/go/geth_adapter/state_db.go
+++ b/go/geth_adapter/state_db.go
@@ -141,7 +141,7 @@ func (s *StateDB) SetState(address common.Address, key common.Hash, value common
 }
 
 func (s *StateDB) GetStorageRoot(address common.Address) common.Hash {
-	if s.context.HasEmptyStateRoot(tosca.Address(address)) {
+	if s.context.HasEmptyStorage(tosca.Address(address)) {
 		return common.Hash{}
 	}
 	return common.Hash{0x42} // non empty root hash

--- a/go/geth_adapter/state_db.go
+++ b/go/geth_adapter/state_db.go
@@ -66,6 +66,7 @@ func (s *StateDB) CreateAccount(common.Address) {
 
 func (s *StateDB) CreateContract(address common.Address) {
 	s.createdContract = &address
+	s.context.CreateAccount(tosca.Address(address))
 }
 
 func (s *StateDB) SubBalance(address common.Address, value *uint256.Int, tracing tracing.BalanceChangeReason) {
@@ -140,7 +141,10 @@ func (s *StateDB) SetState(address common.Address, key common.Hash, value common
 }
 
 func (s *StateDB) GetStorageRoot(address common.Address) common.Hash {
-	return common.Hash{} // not implemented
+	if s.context.HasEmptyStateRoot(tosca.Address(address)) {
+		return common.Hash{}
+	}
+	return common.Hash{0x42} // non empty root hash
 }
 
 func (s *StateDB) GetTransientState(address common.Address, key common.Hash) common.Hash {

--- a/go/integration_test/interpreter/test_evm.go
+++ b/go/integration_test/interpreter/test_evm.go
@@ -223,8 +223,13 @@ func (a *runContextAdapter) SelfDestruct(address tosca.Address, beneficiary tosc
 	return balance != (tosca.Value{})
 }
 
-func (a *runContextAdapter) CreateAccount(tosca.Address, tosca.Code) bool {
-	panic("should not be needed for interpreter tests")
+func (a *runContextAdapter) CreateAccount(addr tosca.Address) {
+	// no effect required in interpreter tests
+}
+
+func (a *runContextAdapter) HasEmptyStateRoot(tosca.Address) bool {
+	// not relevant for interpreter tests
+	return true
 }
 
 func (a *runContextAdapter) CreateSnapshot() tosca.Snapshot {

--- a/go/integration_test/interpreter/test_evm.go
+++ b/go/integration_test/interpreter/test_evm.go
@@ -227,7 +227,7 @@ func (a *runContextAdapter) CreateAccount(addr tosca.Address) {
 	// no effect required in interpreter tests
 }
 
-func (a *runContextAdapter) HasEmptyStateRoot(tosca.Address) bool {
+func (a *runContextAdapter) HasEmptyStorage(tosca.Address) bool {
 	// not relevant for interpreter tests
 	return true
 }

--- a/go/integration_test/processor/scenario.go
+++ b/go/integration_test/processor/scenario.go
@@ -132,6 +132,16 @@ func newScenarioContext(initial WorldState) *scenarioContext {
 	}
 }
 
+func (c *scenarioContext) CreateAccount(addr tosca.Address) {
+	c.current[addr] = Account{}
+}
+
+func (c *scenarioContext) HasEmptyStateRoot(addr tosca.Address) bool {
+	return c.current[addr].Nonce == 0 &&
+		c.current[addr].Code == nil &&
+		len(c.current[addr].Storage) == 0
+}
+
 func (c *scenarioContext) AccountExists(addr tosca.Address) bool {
 	return c.GetBalance(addr) != tosca.Value{} || c.GetNonce(addr) != 0 || c.GetCodeSize(addr) != 0
 }

--- a/go/integration_test/processor/scenario.go
+++ b/go/integration_test/processor/scenario.go
@@ -136,10 +136,8 @@ func (c *scenarioContext) CreateAccount(addr tosca.Address) {
 	c.current[addr] = Account{}
 }
 
-func (c *scenarioContext) HasEmptyStateRoot(addr tosca.Address) bool {
-	return c.current[addr].Nonce == 0 &&
-		c.current[addr].Code == nil &&
-		len(c.current[addr].Storage) == 0
+func (c *scenarioContext) HasEmptyStorage(addr tosca.Address) bool {
+	return len(c.current[addr].Storage) == 0
 }
 
 func (c *scenarioContext) AccountExists(addr tosca.Address) bool {

--- a/go/tosca/interpreter.go
+++ b/go/tosca/interpreter.go
@@ -86,6 +86,8 @@ type RunContext interface {
 type TransactionContext interface {
 	WorldState
 
+	CreateAccount(Address)
+
 	CreateSnapshot() Snapshot
 	RestoreSnapshot(Snapshot)
 
@@ -97,6 +99,10 @@ type TransactionContext interface {
 
 	EmitLog(Log)
 	GetLogs() []Log
+
+	// HasEmptyStateRoot returns whether the account has a 0 nonce,
+	// empty storage and empty code.
+	HasEmptyStateRoot(Address) bool
 
 	// GetBlockHash returns the hash of the block with the given number.
 	GetBlockHash(number int64) Hash

--- a/go/tosca/interpreter.go
+++ b/go/tosca/interpreter.go
@@ -86,8 +86,6 @@ type RunContext interface {
 type TransactionContext interface {
 	WorldState
 
-	CreateAccount(Address)
-
 	CreateSnapshot() Snapshot
 	RestoreSnapshot(Snapshot)
 
@@ -99,9 +97,6 @@ type TransactionContext interface {
 
 	EmitLog(Log)
 	GetLogs() []Log
-
-	// HasEmptyStorage returns whether the account has an empty storage.
-	HasEmptyStorage(Address) bool
 
 	// GetBlockHash returns the hash of the block with the given number.
 	GetBlockHash(number int64) Hash

--- a/go/tosca/interpreter.go
+++ b/go/tosca/interpreter.go
@@ -100,9 +100,8 @@ type TransactionContext interface {
 	EmitLog(Log)
 	GetLogs() []Log
 
-	// HasEmptyStateRoot returns whether the account has a 0 nonce,
-	// empty storage and empty code.
-	HasEmptyStateRoot(Address) bool
+	// HasEmptyStorage returns whether the account has an empty storage.
+	HasEmptyStorage(Address) bool
 
 	// GetBlockHash returns the hash of the block with the given number.
 	GetBlockHash(number int64) Hash

--- a/go/tosca/interpreter_mock.go
+++ b/go/tosca/interpreter_mock.go
@@ -323,18 +323,18 @@ func (mr *MockRunContextMockRecorder) GetTransientStorage(arg0, arg1 any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientStorage", reflect.TypeOf((*MockRunContext)(nil).GetTransientStorage), arg0, arg1)
 }
 
-// HasEmptyStateRoot mocks base method.
-func (m *MockRunContext) HasEmptyStateRoot(arg0 Address) bool {
+// HasEmptyStorage mocks base method.
+func (m *MockRunContext) HasEmptyStorage(arg0 Address) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasEmptyStateRoot", arg0)
+	ret := m.ctrl.Call(m, "HasEmptyStorage", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// HasEmptyStateRoot indicates an expected call of HasEmptyStateRoot.
-func (mr *MockRunContextMockRecorder) HasEmptyStateRoot(arg0 any) *gomock.Call {
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockRunContextMockRecorder) HasEmptyStorage(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStateRoot", reflect.TypeOf((*MockRunContext)(nil).HasEmptyStateRoot), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockRunContext)(nil).HasEmptyStorage), arg0)
 }
 
 // HasSelfDestructed mocks base method.
@@ -712,18 +712,18 @@ func (mr *MockTransactionContextMockRecorder) GetTransientStorage(arg0, arg1 any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientStorage", reflect.TypeOf((*MockTransactionContext)(nil).GetTransientStorage), arg0, arg1)
 }
 
-// HasEmptyStateRoot mocks base method.
-func (m *MockTransactionContext) HasEmptyStateRoot(arg0 Address) bool {
+// HasEmptyStorage mocks base method.
+func (m *MockTransactionContext) HasEmptyStorage(arg0 Address) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasEmptyStateRoot", arg0)
+	ret := m.ctrl.Call(m, "HasEmptyStorage", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// HasEmptyStateRoot indicates an expected call of HasEmptyStateRoot.
-func (mr *MockTransactionContextMockRecorder) HasEmptyStateRoot(arg0 any) *gomock.Call {
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockTransactionContextMockRecorder) HasEmptyStorage(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStateRoot", reflect.TypeOf((*MockTransactionContext)(nil).HasEmptyStateRoot), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockTransactionContext)(nil).HasEmptyStorage), arg0)
 }
 
 // HasSelfDestructed mocks base method.

--- a/go/tosca/interpreter_mock.go
+++ b/go/tosca/interpreter_mock.go
@@ -29,6 +29,7 @@ import (
 type MockInterpreter struct {
 	ctrl     *gomock.Controller
 	recorder *MockInterpreterMockRecorder
+	isgomock struct{}
 }
 
 // MockInterpreterMockRecorder is the mock recorder for MockInterpreter.
@@ -67,6 +68,7 @@ func (mr *MockInterpreterMockRecorder) Run(arg0 any) *gomock.Call {
 type MockRunContext struct {
 	ctrl     *gomock.Controller
 	recorder *MockRunContextMockRecorder
+	isgomock struct{}
 }
 
 // MockRunContextMockRecorder is the mock recorder for MockRunContext.
@@ -141,6 +143,18 @@ func (m *MockRunContext) Call(kind CallKind, parameter CallParameters) (CallResu
 func (mr *MockRunContextMockRecorder) Call(kind, parameter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockRunContext)(nil).Call), kind, parameter)
+}
+
+// CreateAccount mocks base method.
+func (m *MockRunContext) CreateAccount(arg0 Address) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CreateAccount", arg0)
+}
+
+// CreateAccount indicates an expected call of CreateAccount.
+func (mr *MockRunContextMockRecorder) CreateAccount(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockRunContext)(nil).CreateAccount), arg0)
 }
 
 // CreateSnapshot mocks base method.
@@ -309,6 +323,20 @@ func (mr *MockRunContextMockRecorder) GetTransientStorage(arg0, arg1 any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientStorage", reflect.TypeOf((*MockRunContext)(nil).GetTransientStorage), arg0, arg1)
 }
 
+// HasEmptyStateRoot mocks base method.
+func (m *MockRunContext) HasEmptyStateRoot(arg0 Address) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStateRoot", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasEmptyStateRoot indicates an expected call of HasEmptyStateRoot.
+func (mr *MockRunContextMockRecorder) HasEmptyStateRoot(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStateRoot", reflect.TypeOf((*MockRunContext)(nil).HasEmptyStateRoot), arg0)
+}
+
 // HasSelfDestructed mocks base method.
 func (m *MockRunContext) HasSelfDestructed(addr Address) bool {
 	m.ctrl.T.Helper()
@@ -444,6 +472,7 @@ func (mr *MockRunContextMockRecorder) SetTransientStorage(arg0, arg1, arg2 any) 
 type MockTransactionContext struct {
 	ctrl     *gomock.Controller
 	recorder *MockTransactionContextMockRecorder
+	isgomock struct{}
 }
 
 // MockTransactionContextMockRecorder is the mock recorder for MockTransactionContext.
@@ -503,6 +532,18 @@ func (m *MockTransactionContext) AccountExists(arg0 Address) bool {
 func (mr *MockTransactionContextMockRecorder) AccountExists(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountExists", reflect.TypeOf((*MockTransactionContext)(nil).AccountExists), arg0)
+}
+
+// CreateAccount mocks base method.
+func (m *MockTransactionContext) CreateAccount(arg0 Address) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CreateAccount", arg0)
+}
+
+// CreateAccount indicates an expected call of CreateAccount.
+func (mr *MockTransactionContextMockRecorder) CreateAccount(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockTransactionContext)(nil).CreateAccount), arg0)
 }
 
 // CreateSnapshot mocks base method.
@@ -671,6 +712,20 @@ func (mr *MockTransactionContextMockRecorder) GetTransientStorage(arg0, arg1 any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientStorage", reflect.TypeOf((*MockTransactionContext)(nil).GetTransientStorage), arg0, arg1)
 }
 
+// HasEmptyStateRoot mocks base method.
+func (m *MockTransactionContext) HasEmptyStateRoot(arg0 Address) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStateRoot", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasEmptyStateRoot indicates an expected call of HasEmptyStateRoot.
+func (mr *MockTransactionContextMockRecorder) HasEmptyStateRoot(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStateRoot", reflect.TypeOf((*MockTransactionContext)(nil).HasEmptyStateRoot), arg0)
+}
+
 // HasSelfDestructed mocks base method.
 func (m *MockTransactionContext) HasSelfDestructed(addr Address) bool {
 	m.ctrl.T.Helper()
@@ -806,6 +861,7 @@ func (mr *MockTransactionContextMockRecorder) SetTransientStorage(arg0, arg1, ar
 type MockProfilingInterpreter struct {
 	ctrl     *gomock.Controller
 	recorder *MockProfilingInterpreterMockRecorder
+	isgomock struct{}
 }
 
 // MockProfilingInterpreterMockRecorder is the mock recorder for MockProfilingInterpreter.

--- a/go/tosca/world_state.go
+++ b/go/tosca/world_state.go
@@ -20,6 +20,8 @@ import "fmt"
 type WorldState interface {
 	AccountExists(Address) bool
 
+	CreateAccount(Address)
+
 	GetBalance(Address) Value
 	SetBalance(Address, Value)
 
@@ -31,6 +33,8 @@ type WorldState interface {
 	GetCodeSize(Address) int
 	SetCode(Address, Code)
 
+	// HasEmptyStorage returns whether the account has an empty storage.
+	HasEmptyStorage(Address) bool
 	GetStorage(Address, Key) Word
 	SetStorage(Address, Key, Word) StorageStatus
 

--- a/go/tosca/world_state_mock.go
+++ b/go/tosca/world_state_mock.go
@@ -29,6 +29,7 @@ import (
 type MockWorldState struct {
 	ctrl     *gomock.Controller
 	recorder *MockWorldStateMockRecorder
+	isgomock struct{}
 }
 
 // MockWorldStateMockRecorder is the mock recorder for MockWorldState.
@@ -60,6 +61,18 @@ func (m *MockWorldState) AccountExists(arg0 Address) bool {
 func (mr *MockWorldStateMockRecorder) AccountExists(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountExists", reflect.TypeOf((*MockWorldState)(nil).AccountExists), arg0)
+}
+
+// CreateAccount mocks base method.
+func (m *MockWorldState) CreateAccount(arg0 Address) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CreateAccount", arg0)
+}
+
+// CreateAccount indicates an expected call of CreateAccount.
+func (mr *MockWorldStateMockRecorder) CreateAccount(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockWorldState)(nil).CreateAccount), arg0)
 }
 
 // GetBalance mocks base method.
@@ -144,6 +157,20 @@ func (m *MockWorldState) GetStorage(arg0 Address, arg1 Key) Word {
 func (mr *MockWorldStateMockRecorder) GetStorage(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorage", reflect.TypeOf((*MockWorldState)(nil).GetStorage), arg0, arg1)
+}
+
+// HasEmptyStorage mocks base method.
+func (m *MockWorldState) HasEmptyStorage(arg0 Address) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockWorldStateMockRecorder) HasEmptyStorage(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockWorldState)(nil).HasEmptyStorage), arg0)
 }
 
 // SelfDestruct mocks base method.


### PR DESCRIPTION
The transaction context interface has been extended by two functions, `CreateAccount` and `HasEmptyStateRoot`. Both are required by the processor to manage account life times in create and selfdestruct instructions.