### PR TITLE
Set block gas limit

### DIFF
--- a/go/examples/example.go
+++ b/go/examples/example.go
@@ -78,7 +78,7 @@ func (e *Example) RunOn(interpreter tosca.Interpreter, argument int) (Result, er
 func (e *Example) RunOnProcessor(processor tosca.Processor, argument int,
 	transaction tosca.Transaction, transactionContext tosca.TransactionContext) (Result, error) {
 
-	blockParameters := tosca.BlockParameters{}
+	blockParameters := tosca.BlockParameters{GasLimit: transaction.GasLimit}
 	transaction.Input = encodeArgument(e.function, argument)
 
 	receipt, err := processor.Run(blockParameters, transaction, transactionContext)

--- a/go/integration_test/processor/access_list_test.go
+++ b/go/integration_test/processor/access_list_test.go
@@ -78,8 +78,6 @@ func TestProcessor_AccessListIsHandledCorrectly(t *testing.T) {
 					byte(vm.RETURN),
 				}...)
 
-				blockParams := tosca.BlockParameters{Revision: tosca.R09_Berlin}
-
 				transaction := tosca.Transaction{
 					Sender:     sender,
 					Recipient:  receiver,
@@ -87,6 +85,8 @@ func TestProcessor_AccessListIsHandledCorrectly(t *testing.T) {
 					Nonce:      0,
 					AccessList: test.accessList,
 				}
+
+				blockParams := tosca.BlockParameters{GasLimit: transaction.GasLimit, Revision: tosca.R09_Berlin}
 				scenario := getScenarioContext(sender, *receiver, code, gas)
 				transactionContext := newScenarioContext(scenario.Before)
 

--- a/go/integration_test/processor/calls_test.go
+++ b/go/integration_test/processor/calls_test.go
@@ -99,7 +99,6 @@ func TestProcessor_MaximalCallDepthIsEnforced(t *testing.T) {
 				byte(vm.RETURN),
 			}...)
 
-			blockParams := tosca.BlockParameters{}
 			transaction := tosca.Transaction{
 				Sender:    sender,
 				Recipient: receiver,
@@ -107,6 +106,8 @@ func TestProcessor_MaximalCallDepthIsEnforced(t *testing.T) {
 				Nonce:     0,
 				Input:     tosca.Data{},
 			}
+
+			blockParams := tosca.BlockParameters{GasLimit: transaction.GasLimit}
 			scenario := getScenarioContext(sender, *receiver, code, sufficientGas)
 			transactionContext := newScenarioContext(scenario.Before)
 
@@ -176,7 +177,7 @@ func TestProcessor_DifferentCallTypesAccessStorage(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil || !result.Success {
 					t.Errorf("execution was not successful or failed with error %v", err)
 				}
@@ -239,7 +240,7 @@ func TestProcessor_DifferentCallTypesHandleValueCorrectly(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil || !result.Success {
 					t.Errorf("execution was not successful or failed with error %v", err)
 				}
@@ -303,7 +304,7 @@ func TestProcessor_DifferentCallTypesSetTheCorrectSender(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil || !result.Success {
 					t.Errorf("execution was not successful or failed with error %v", err)
 				}
@@ -384,7 +385,7 @@ func TestProcessor_RecursiveCallsAfterAStaticCallAreStatic(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil || !result.Success {
 					t.Errorf("execution was not successful or failed with error %v", err)
 				}
@@ -438,7 +439,7 @@ func TestProcessor_CallingNonExistentAccountIsHandledCorrectly(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil {
 					t.Errorf("execution failed with error %v", err)
 				}

--- a/go/integration_test/processor/create_test.go
+++ b/go/integration_test/processor/create_test.go
@@ -137,7 +137,7 @@ func TestProcessor_CreateAndCallContract(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil || !result.Success {
 					t.Errorf("execution was not successful or failed with error %v", err)
 				}
@@ -287,7 +287,7 @@ func TestProcessor_CreateInitCodeIsExecutedInRightContext(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil || !result.Success {
 					t.Errorf("execution was not successful or failed with error %v", err)
 				}
@@ -328,7 +328,7 @@ func TestProcessor_EmptyReceiverCreatesAccount(t *testing.T) {
 		transactionContext := newScenarioContext(state)
 
 		// Run the processor
-		result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+		result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 		if err != nil || !result.Success {
 			t.Errorf("execution was not successful or failed with error %v", err)
 		}
@@ -451,7 +451,7 @@ func TestProcessor_CorrectAddressIsCreated(t *testing.T) {
 				}
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil || !result.Success {
 					t.Errorf("execution was not successful or failed with error %v", err)
 				}
@@ -531,7 +531,7 @@ func TestProcessor_CreateExistingAccountFails(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil {
 					t.Errorf("execution failed with error %v", err)
 				}
@@ -626,7 +626,7 @@ func TestProcessor_CodeStartingWith0xEFCanNotBeCreated(t *testing.T) {
 					Input:     initCode,
 				}
 
-				blockParameters := tosca.BlockParameters{Revision: test.revision}
+				blockParameters := tosca.BlockParameters{GasLimit: transaction.GasLimit, Revision: test.revision}
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
@@ -692,7 +692,7 @@ func TestProcessor_CodeSizeIsLimited(t *testing.T) {
 					Input:     initCode,
 				}
 
-				blockParameters := tosca.BlockParameters{}
+				blockParameters := tosca.BlockParameters{GasLimit: transaction.GasLimit}
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor

--- a/go/integration_test/processor/precompiled_test.go
+++ b/go/integration_test/processor/precompiled_test.go
@@ -91,7 +91,7 @@ func TestProcessor_PreCompiledContractsCanBeProcessed(t *testing.T) {
 				}
 
 				transactionContext := newScenarioContext(state)
-				blockParameters := tosca.BlockParameters{Revision: tosca.R13_Cancun}
+				blockParameters := tosca.BlockParameters{GasLimit: transaction.GasLimit, Revision: tosca.R13_Cancun}
 
 				// Run the processor
 				result, err := processor.Run(blockParameters, transaction, transactionContext)
@@ -175,7 +175,7 @@ func TestPrecompiled_StatePrecompiledContractSetBalance(t *testing.T) {
 			}
 
 			transactionContext := newScenarioContext(state)
-			blockParameters := tosca.BlockParameters{Revision: tosca.R13_Cancun}
+			blockParameters := tosca.BlockParameters{GasLimit: transaction.GasLimit, Revision: tosca.R13_Cancun}
 
 			// Run the processor
 			result, err := processor.Run(blockParameters, transaction, transactionContext)

--- a/go/integration_test/processor/scenario.go
+++ b/go/integration_test/processor/scenario.go
@@ -35,6 +35,11 @@ type Scenario struct {
 func (s *Scenario) Run(t *testing.T, processor tosca.Processor) {
 
 	context := newScenarioContext(s.Before)
+
+	if s.Transaction.GasLimit != 0 && s.Parameters.GasLimit == 0 {
+		s.Parameters.GasLimit = s.Transaction.GasLimit
+	}
+
 	receipt, err := processor.Run(s.Parameters, s.Transaction, context)
 	if err != nil && s.OperaError == nil {
 		t.Fatalf("failed to run transaction: %v", err)

--- a/go/integration_test/processor/transfer_test.go
+++ b/go/integration_test/processor/transfer_test.go
@@ -62,7 +62,7 @@ func TestProcessor_CallValueTransfersAreHandledCorrectly(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil || !result.Success {
 					t.Fatalf("execution was not successful or failed with error %v", err)
 				}
@@ -137,7 +137,7 @@ func TestProcessor_CallsWithInsufficientBalanceAreHandledCorrectly(t *testing.T)
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil || !result.Success {
 					t.Fatalf("execution was not successful or failed with error %v", err)
 				}
@@ -202,7 +202,7 @@ func TestProcessor_TransferToSelf(t *testing.T) {
 				transactionContext := newScenarioContext(state)
 
 				// Run the processor
-				result, err := processor.Run(tosca.BlockParameters{}, transaction, transactionContext)
+				result, err := processor.Run(tosca.BlockParameters{GasLimit: transaction.GasLimit}, transaction, transactionContext)
 				if err != nil {
 					t.Fatalf("execution failed with error %v", err)
 				}

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -76,7 +76,7 @@ func (p *Processor) Run(
 	evm := vm.NewEVM(blockContext, txContext, stateDB, chainConfig, config)
 
 	msg := transactionToMessage(transaction, gasPrice, blobHashes)
-	gasPool := new(core.GasPool).AddGas(uint64(transaction.GasLimit))
+	gasPool := new(core.GasPool).AddGas(uint64(blockParameters.GasLimit))
 
 	snapshot := context.CreateSnapshot()
 	result, err := core.ApplyMessage(evm, msg, gasPool)

--- a/go/processor/geth/processor_test.go
+++ b/go/processor/geth/processor_test.go
@@ -92,13 +92,15 @@ func TestGethProcessor_ConfigAddsStateContract(t *testing.T) {
 	}
 }
 
-func TestGethProcessor_BlockGasLimitIsEnforces(t *testing.T) {
+func TestGethProcessor_BlockGasLimitIsEnforced(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	interpreter := tosca.NewMockInterpreter(ctrl)
 	context := tosca.NewMockTransactionContext(ctrl)
+	context.EXPECT().CreateSnapshot().Return(tosca.Snapshot(0))
 	context.EXPECT().GetNonce(gomock.Any()).Return(uint64(0))
 	context.EXPECT().GetCodeHash(gomock.Any()).Return(tosca.Hash{})
 	context.EXPECT().GetBalance(gomock.Any()).Return(tosca.NewValue(1000))
+	context.EXPECT().RestoreSnapshot(gomock.Any())
 
 	transaction := tosca.Transaction{
 		GasLimit: 1000,


### PR DESCRIPTION
Geth's gas pool is used per block, it ensures the upper bound for gas in a block is not exceeded. 
The processor checks the gas limit in the beginning of the transaction when the gas is bought.