### PR TITLE
Geth: reset return data

### DIFF
--- a/go/ct/common/bytes.go
+++ b/go/ct/common/bytes.go
@@ -43,6 +43,13 @@ func RandomBytesOfSize(rnd *rand.Rand, size int) Bytes {
 	return NewBytes(data)
 }
 
+func (b Bytes) Eq(other Bytes) bool {
+	if (b.data == "" || b.data == "0x") && (other.data == "" || other.data == "0x") {
+		return true
+	}
+	return b.data == other.data
+}
+
 func (b Bytes) ToBytes() []byte {
 	return []byte(b.data)
 }

--- a/go/ct/common/bytes_test.go
+++ b/go/ct/common/bytes_test.go
@@ -149,3 +149,54 @@ func TestBytes_Get(t *testing.T) {
 		t.Errorf("unexpected slice, got %v", got)
 	}
 }
+
+func TestBytes_EqHandlesEmptyAndNilTheSameWay(t *testing.T) {
+	tests := map[string]struct {
+		first  Bytes
+		second Bytes
+		equal  bool
+	}{
+		"both empty": {
+			first:  NewBytes([]byte{}),
+			second: NewBytes([]byte{}),
+			equal:  true,
+		},
+		"first empty": {
+			first:  NewBytes([]byte{}),
+			second: NewBytes([]byte{1}),
+			equal:  false,
+		},
+		"second empty": {
+			first:  NewBytes([]byte{1}),
+			second: NewBytes([]byte{}),
+			equal:  false,
+		},
+		"both nil": {
+			first:  Bytes{},
+			second: Bytes{},
+			equal:  true,
+		},
+		"first nil": {
+			first:  Bytes{},
+			second: NewBytes([]byte{}),
+			equal:  true,
+		},
+		"second nil": {
+			first:  NewBytes([]byte{}),
+			second: Bytes{},
+			equal:  true,
+		},
+		"nil and non empty": {
+			first:  Bytes{},
+			second: NewBytes([]byte{1}),
+			equal:  false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := test.first.Eq(test.second); got != test.equal {
+				t.Errorf("unexpected equality, got %v", got)
+			}
+		})
+	}
+}

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -240,7 +240,7 @@ func (s *State) Eq(other *State) bool {
 		s.CallContext == other.CallContext &&
 		s.CallJournal.Equal(other.CallJournal) &&
 		s.BlockContext == other.BlockContext &&
-		s.CallData == other.CallData &&
+		s.CallData.Eq(other.CallData) &&
 		s.Storage.Eq(other.Storage) &&
 		s.TransientStorage.Eq(other.TransientStorage) &&
 		s.Accounts.Eq(other.Accounts) &&
@@ -253,7 +253,7 @@ func (s *State) Eq(other *State) bool {
 	// For terminal states, internal state can be ignored, but the result is important.
 	if s.Status != Running {
 		return equivalent &&
-			s.ReturnData == other.ReturnData
+			s.ReturnData.Eq(other.ReturnData)
 	}
 
 	// All PC beyond the end of the code are equal, as all PCs in this range
@@ -266,7 +266,7 @@ func (s *State) Eq(other *State) bool {
 		equivalentPc &&
 		s.Stack.Eq(other.Stack) &&
 		s.Memory.Eq(other.Memory) &&
-		s.LastCallReturnData == other.LastCallReturnData
+		s.LastCallReturnData.Eq(other.LastCallReturnData)
 }
 
 const dataCutoffLength = 20
@@ -467,11 +467,11 @@ func (s *State) Diff(o *State) []string {
 		res = append(res, s.TransactionContext.Diff(o.TransactionContext)...)
 	}
 
-	if s.CallData != o.CallData {
+	if !s.CallData.Eq(o.CallData) {
 		res = append(res, fmt.Sprintf("Different call data: %x vs %x", s.CallData, o.CallData))
 	}
 
-	if s.LastCallReturnData != o.LastCallReturnData {
+	if !s.LastCallReturnData.Eq(o.LastCallReturnData) {
 		res = append(res, fmt.Sprintf("Different last call return data: %x vs %x.", s.LastCallReturnData, o.LastCallReturnData))
 	}
 

--- a/regression_inputs/no_code_#27.json
+++ b/regression_inputs/no_code_#27.json
@@ -1,0 +1,20 @@
+{
+    "Status": "running",
+    "Revision": "Paris",
+    "ReadOnly": false,
+    "Pc": 0,
+    "Gas": 102879607652,
+    "GasRefund": 173544765271,
+    "Code": "",
+    "Stack": [
+        "6cdc7fb5398d465c a434dfd544911699 7329d5cddb336bdc 4556f2f7f27e8668",
+        "fdb3ae278d9d379e 69f27280f570334d ffd3f34b71109167 957f5ff5c0508f25",
+        "bea391978dacce93 40b88a6c4c0c5e5f f8dd98532b8ff077 50f800737d405bc8",
+        "ee34236780c7da9b badff3c484f7be58 19a755c7585eae7b 0e892a9105a7da3f",
+        "5d3be04d4cbf9de7 e84426507b4d17ce 8f420a6c85347168 1b9368da77027959"
+    ],
+    	"CallData": "348939920e94fcbfa91818837629c539d234df03",
+    	"LastCallReturnData": "b87add9ca4cf959a617270a5d4a31567a47004d2",
+    	"ReturnData": "3078",
+    	"HasSelfDestructed": false
+    }


### PR DESCRIPTION
A nightly CT [run](https://scala.fantom.network/job/Tosca/job/Conformance%20Tests%20Geth/24/) failed.
The CT uses its own `Bytes` type which uses a golang string internally, for our use case an empty string and nil should be handled the same way.