### PR TITLE
EVMZERO: Fix issue in C++ coverage system

### DIFF
--- a/cpp/cmake/tosca_coverage.cmake
+++ b/cpp/cmake/tosca_coverage.cmake
@@ -17,6 +17,9 @@ if(TOSCA_COVERAGE)
   add_link_options(--coverage)
   add_definitions(-DTOSCA_COVERAGE=1)
 
+  find_program(LCOV lcov REQUIRED)
+  find_program(GENHTML genhtml REQUIRED)
+
   add_custom_target(coverage
     COMMENT "Generating coverage report."
 


### PR DESCRIPTION
At some point during development, the required programs to compute C++ coverage and prepare reports were removed. 
This was not detected because cmake keeps a cache in the developer machine.

This PR re-introduces required infrastructure for c++ coverage. 
This issue was detected during Issues migration from the old organization. 