### PR TITLE
EVMZERO: Enable fuzzing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ build/
 
 # Jenkinsfile linter config
 .groovylintrc.json
+
+# vscode c++ engine cache
+.cache

--- a/go/ct/evm_fuzz_test.go
+++ b/go/ct/evm_fuzz_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/0xsoniclabs/tosca/go/ct"
 	. "github.com/0xsoniclabs/tosca/go/ct/common"
 	"github.com/0xsoniclabs/tosca/go/ct/st"
+	"github.com/0xsoniclabs/tosca/go/interpreter/evmzero"
 	"github.com/0xsoniclabs/tosca/go/interpreter/geth"
 	"github.com/0xsoniclabs/tosca/go/interpreter/lfvm"
 	"github.com/0xsoniclabs/tosca/go/tosca"
@@ -37,10 +38,10 @@ func FuzzLfvm(f *testing.F) {
 	fuzzVm(lfvm.NewConformanceTestingTarget(), f)
 }
 
-// FuzzLfvm is a fuzzing test for evmzero, (issue #549 )
-// func FuzzEvmzero(f *testing.F) {
-// 	fuzzVm(evmzero.NewConformanceTestingTarget(), f)
-// }
+// FuzzLfvm is a fuzzing test for evmzero
+func FuzzEvmzero(f *testing.F) {
+	fuzzVm(evmzero.NewConformanceTestingTarget(), f)
+}
 
 // FuzzDifferentialLfvmVsGeth compares state output between lfvm and geth
 func FuzzDifferentialLfvmVsGeth(f *testing.F) {
@@ -50,16 +51,13 @@ func FuzzDifferentialLfvmVsGeth(f *testing.F) {
 	)
 }
 
-// TODO: This test makes sense but cannot be enabled yet:
-// - The evmzero fails the differential test against geth. (issue #549)
-// - Any other invocation of fuzzing tests in this file seem to
-// invoke the all other tests in the file, and they will fail.
-// func FuzzDifferentialEvmzeroVsGeth(f *testing.F) {
-// 	differentialFuzz(f,
-// 		evmzero.NewConformanceTestingTarget(),
-// 		geth.NewConformanceTestingTarget(),
-// 	)
-// }
+// FuzzDifferentialLfvmVsGeth compares state output between evmzero and geth
+func FuzzDifferentialEvmzeroVsGeth(f *testing.F) {
+	differentialFuzz(f,
+		evmzero.NewConformanceTestingTarget(),
+		geth.NewConformanceTestingTarget(),
+	)
+}
 
 //////////////////////////////////////////////////////////////////////////////
 // Fuzzing helpers


### PR DESCRIPTION
During migration of old organization issues [issue 549](https://github.com/Fantom-foundation/Tosca/issues/549) was found.
The stated error cannot be reproduced anymore, and evmzero fuzzer (go-driven)  can be enabled.  This means that the fuzzer test will be treated as an unit test for each corpus (generated and stored)  during unit testing rounds.
Additionally it allows to fuzz the C++ vm.

- `go test -fuzz=FuzzEvmzero ./go/ct`
- `go test -fuzz=FuzzDifferentialEvmzeroVsGeth ./go/ct`


