### PR TITLE
Update evmc dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/ethereum/evmone.git
 [submodule "third_party/evmc"]
 	path = third_party/evmc
-	url = https://github.com/Fantom-foundation/evmc.git
+	url = https://github.com/0xsoniclabs/evmc.git
 [submodule "third_party/intx"]
 	path = third_party/intx
 	url = https://github.com/chfast/intx.git


### PR DESCRIPTION
The [emvc repo](https://github.com/0xsoniclabs/evmc) has been added to the new organization. Its `tosca-extensions` branch has also been rebased to the latest changes of the base branch.