### PR TITLE
Add CT support to check EIP-7702 semantics. 

### DIFF
--- a/go/ct/common/delegator_designator.go
+++ b/go/ct/common/delegator_designator.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package common
+
+import (
+	"bytes"
+
+	"github.com/0xsoniclabs/tosca/go/tosca"
+)
+
+// ParseDelegationDesignator returns the delegate from a code
+// segment containing a delegation designator, if any.
+// If the code segment does not contain a delegation designator,
+// second returned value is false, and the address shall be ignored.
+// see: https://eips.ethereum.org/EIPS/eip-7702
+func ParseDelegationDesignator(code Bytes) (tosca.Address, bool) {
+	raw := code.ToBytes()
+
+	if len(raw) < 23 {
+		return tosca.Address{}, false
+	}
+
+	if bytes.HasPrefix(raw, []byte{0xef, 0x01, 0x00}) {
+		var res tosca.Address
+		copy(res[:], raw[3:23])
+		return res, true
+	}
+	return tosca.Address{}, false
+}
+
+// NewDelegationDesignator creates a new delegation designator for the given address.
+// see: https://eips.ethereum.org/EIPS/eip-7702
+func NewDelegationDesignator(address tosca.Address) Bytes {
+	return NewBytes(append([]byte{0xef, 0x01, 0x00}, address[:]...))
+}

--- a/go/ct/common/delegator_designator.go
+++ b/go/ct/common/delegator_designator.go
@@ -24,7 +24,7 @@ import (
 func ParseDelegationDesignator(code Bytes) (tosca.Address, bool) {
 	raw := code.ToBytes()
 
-	if len(raw) < 23 {
+	if len(raw) != 23 {
 		return tosca.Address{}, false
 	}
 

--- a/go/ct/common/delegator_designator_test.go
+++ b/go/ct/common/delegator_designator_test.go
@@ -28,13 +28,16 @@ func TestParseDelegationDesignator(t *testing.T) {
 		expectedResult tosca.Address
 	}{
 		"empty": {},
-		"wrong length": {
+		"too short": {
 			code: NewBytes([]byte{0xef, 0x01, 0x00, 0xab}),
 		},
 		"delegation designator": {
 			code:           NewBytes(append([]byte{0xef, 0x01, 0x00}, address[:]...)),
 			expectedParsed: true,
 			expectedResult: address,
+		},
+		"too long": {
+			code: NewBytes(append(append([]byte{0xef, 0x01, 0x00}, address[:]...), 0xab)),
 		},
 	}
 

--- a/go/ct/common/delegator_designator_test.go
+++ b/go/ct/common/delegator_designator_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package common
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/0xsoniclabs/tosca/go/tosca"
+)
+
+func TestParseDelegationDesignator(t *testing.T) {
+
+	address := tosca.Address{}
+	_, _ = rand.Read(address[:])
+
+	tests := map[string]struct {
+		code           Bytes
+		expectedParsed bool
+		expectedResult tosca.Address
+	}{
+		"empty": {},
+		"wrong length": {
+			code: NewBytes([]byte{0xef, 0x01, 0x00, 0xab}),
+		},
+		"delegation designator": {
+			code:           NewBytes(append([]byte{0xef, 0x01, 0x00}, address[:]...)),
+			expectedParsed: true,
+			expectedResult: address,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			result, parsed := ParseDelegationDesignator(test.code)
+			if parsed != test.expectedParsed {
+				t.Errorf("want: %v, got: %v", test.expectedParsed, parsed)
+			}
+
+			if test.expectedParsed && result != test.expectedResult {
+				t.Errorf("want: %v, got: %v", result, test.expectedParsed)
+			}
+		})
+	}
+}
+
+func TestDelegationDesignator_CanBeWrittenAndParsed(t *testing.T) {
+	address := tosca.Address{}
+	_, _ = rand.Read(address[:])
+	designator := NewDelegationDesignator(address)
+
+	result, parsed := ParseDelegationDesignator(designator)
+	if !parsed {
+		t.Errorf("could not parse delegation designator")
+	}
+
+	if address != result {
+		t.Errorf("want: %v, got: %v", &address, parsed)
+	}
+}

--- a/go/ct/gen/accounts.go
+++ b/go/ct/gen/accounts.go
@@ -444,7 +444,7 @@ func (a *delegationDesignatorConstraint) String() string {
 		return fmt.Sprintf("!isDelegated(%v)", a.address)
 	}
 	if a.delegateAccountStatus == tosca.WarmAccess {
-		return fmt.Sprintf("isDelegated(%v), warm(delegateOf(%v))", a.address, a.address)
+		return fmt.Sprintf("isDelegated(%v),warm(delegateOf(%v))", a.address, a.address)
 	}
-	return fmt.Sprintf("isDelegated(%v), cold(delegateOf(%v))", a.address, a.address)
+	return fmt.Sprintf("isDelegated(%v),cold(delegateOf(%v))", a.address, a.address)
 }

--- a/go/ct/gen/accounts.go
+++ b/go/ct/gen/accounts.go
@@ -149,8 +149,18 @@ func (g *AccountsGenerator) String() string {
 		parts = append(parts, fmt.Sprintf("balance(%v) ≤ %v", con.address, con.value.DecimalString()))
 	}
 
+	sort.Slice(g.DelegationDesignator, func(i, j int) bool {
+		return g.DelegationDesignator[i].Less(&g.DelegationDesignator[j])
+	})
 	for _, con := range g.DelegationDesignator {
-		parts = append(parts, fmt.Sprintf("DelegationDesignator(%v) = %v", con.addressVariable, con.accessKind))
+		access := "none"
+		if con.enabled {
+			access = "warm"
+			if con.accessKind == tosca.ColdAccess {
+				access = "cold"
+			}
+		}
+		parts = append(parts, fmt.Sprintf("DelegationDesignator(%v) = %v", con.addressVariable, access))
 	}
 
 	return "{" + strings.Join(parts, ",") + "}"

--- a/go/ct/gen/accounts.go
+++ b/go/ct/gen/accounts.go
@@ -98,7 +98,7 @@ func (g *AccountsGenerator) BindCold(address Variable) {
 	}
 }
 
-func (g *AccountsGenerator) BindDelegationDesignator(address Variable, delegateAccountStatus tosca.AccessStatus) {
+func (g *AccountsGenerator) BindToAddressOfDelegatedAccount(address Variable, delegateAccountStatus tosca.AccessStatus) {
 	v := delegationDesignatorConstraint{address, true, delegateAccountStatus}
 	if !slices.Contains(g.delegationDesignator, v) {
 		g.delegationDesignator = append(g.delegationDesignator, v)

--- a/go/ct/gen/accounts.go
+++ b/go/ct/gen/accounts.go
@@ -98,14 +98,14 @@ func (g *AccountsGenerator) BindCold(address Variable) {
 	}
 }
 
-func (g *AccountsGenerator) BindToAddressOfDelegatedAccount(address Variable, delegateAccountStatus tosca.AccessStatus) {
+func (g *AccountsGenerator) BindToAddressOfDelegatingAccount(address Variable, delegateAccountStatus tosca.AccessStatus) {
 	v := delegationDesignatorConstraint{address, true, delegateAccountStatus}
 	if !slices.Contains(g.delegationDesignator, v) {
 		g.delegationDesignator = append(g.delegationDesignator, v)
 	}
 }
 
-func (g *AccountsGenerator) BindNoDelegationDesignator(address Variable) {
+func (g *AccountsGenerator) BindToAddressOfNotDelegatingAccount(address Variable) {
 	v := delegationDesignatorConstraint{address: address, isDelegated: false}
 	if !slices.Contains(g.delegationDesignator, v) {
 		g.delegationDesignator = append(g.delegationDesignator, v)

--- a/go/ct/gen/accounts_test.go
+++ b/go/ct/gen/accounts_test.go
@@ -212,9 +212,13 @@ func TestAccountsGenerator_DelegationDesignatorConstraintsAreUsed(t *testing.T) 
 				delegateAddress, isDesignator := ParseDelegationDesignator(account.Code)
 				if !isDesignator {
 					t.Errorf("Expected address to be a delegation designator but it is not")
-				} else if test.access !=
-					tosca.AccessStatus(accounts.IsWarm(delegateAddress)) {
-					t.Errorf("Expected address to be %v but it is not", test.access)
+				} else {
+					if test.access == tosca.WarmAccess && !accounts.IsWarm(delegateAddress) {
+						t.Errorf("Expected address to be warm but it is not")
+					}
+					if test.access == tosca.ColdAccess && accounts.IsWarm(delegateAddress) {
+						t.Errorf("Expected address to be warm but it is not")
+					}
 				}
 			}
 		})

--- a/go/ct/gen/accounts_test.go
+++ b/go/ct/gen/accounts_test.go
@@ -96,6 +96,57 @@ func TestAccountsGenerator_WarmColdConstraintsNoAssignment(t *testing.T) {
 	}
 }
 
+func TestAccountsGenerator_DelegationDesignatorCanBePrinted(t *testing.T) {
+
+	tests := map[string]struct {
+		setup    func(*AccountsGenerator, Variable)
+		expected string
+	}{
+		"no delegation designator": {
+			setup: func(gen *AccountsGenerator, v Variable) {
+				gen.BindNoDelegationDesignator(v)
+			},
+			expected: "{DelegationDesignator($v1) = none}",
+		},
+		"delegate is cold": {
+			setup: func(gen *AccountsGenerator, v Variable) {
+				gen.BindDelegationDesignator(v, tosca.ColdAccess)
+			},
+			expected: "{DelegationDesignator($v1) = cold}",
+		},
+		"delegate is warm": {
+			setup: func(gen *AccountsGenerator, v Variable) {
+				gen.BindDelegationDesignator(v, tosca.WarmAccess)
+			},
+			expected: "{DelegationDesignator($v1) = warm}",
+		},
+		"is sorted": {
+			setup: func(gen *AccountsGenerator, v Variable) {
+				v2 := Variable("v2")
+				gen.BindDelegationDesignator(v2, tosca.WarmAccess)
+				gen.BindNoDelegationDesignator(v)
+			},
+			expected: "{DelegationDesignator($v1) = none,DelegationDesignator($v2) = warm}",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			v1 := Variable("v1")
+
+			generator := NewAccountGenerator()
+			test.setup(generator, v1)
+
+			print := generator.String()
+			if print != test.expected {
+				t.Errorf("Expected %v but got %v", test.expected, print)
+			}
+
+		})
+	}
+}
+
 func TestAccountsGenerator_DelegationDesignatorConstraintsAreUsed(t *testing.T) {
 
 	tests := map[string]struct {

--- a/go/ct/gen/accounts_test.go
+++ b/go/ct/gen/accounts_test.go
@@ -110,20 +110,20 @@ func TestAccountsGenerator_DelegationDesignatorCanBePrinted(t *testing.T) {
 		},
 		"delegate is cold": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindDelegationDesignator(v, tosca.ColdAccess)
+				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
 			},
 			expected: "{isDelegated($v1), cold(delegateOf($v1))}",
 		},
 		"delegate is warm": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindDelegationDesignator(v, tosca.WarmAccess)
+				gen.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
 			},
 			expected: "{isDelegated($v1), warm(delegateOf($v1))}",
 		},
 		"is sorted": {
 			setup: func(gen *AccountsGenerator, v Variable) {
 				v2 := Variable("v2")
-				gen.BindDelegationDesignator(v2, tosca.WarmAccess)
+				gen.BindToAddressOfDelegatedAccount(v2, tosca.WarmAccess)
 				gen.BindNoDelegationDesignator(v)
 			},
 			expected: "{!isDelegated($v1),isDelegated($v2), warm(delegateOf($v2))}",
@@ -161,14 +161,14 @@ func TestAccountsGenerator_DelegationDesignatorConstraintsAreUsed(t *testing.T) 
 		},
 		"delegate is cold": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindDelegationDesignator(v, tosca.ColdAccess)
+				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
 			},
 			withDelegate: true,
 			access:       tosca.ColdAccess,
 		},
 		"delegate is warm": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindDelegationDesignator(v, tosca.WarmAccess)
+				gen.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
 			},
 			withDelegate: true,
 			access:       tosca.WarmAccess,
@@ -228,24 +228,24 @@ func TestAccountsGenerator_DelegationDesignatorCanConflictWithOtherRules(t *test
 		"disable and warm": {
 			constraint: func(gen *AccountsGenerator, v Variable) {
 				gen.BindNoDelegationDesignator(v)
-				gen.BindDelegationDesignator(v, tosca.WarmAccess)
+				gen.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
 			},
 		},
 		"disable and cold": {
 			constraint: func(gen *AccountsGenerator, v Variable) {
 				gen.BindNoDelegationDesignator(v)
-				gen.BindDelegationDesignator(v, tosca.ColdAccess)
+				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
 			},
 		},
 		"cold and warm": {
 			constraint: func(gen *AccountsGenerator, v Variable) {
-				gen.BindDelegationDesignator(v, tosca.ColdAccess)
-				gen.BindDelegationDesignator(v, tosca.WarmAccess)
+				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
+				gen.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
 			},
 		},
 		"empty and contains designator conflict": {
 			constraint: func(gen *AccountsGenerator, v Variable) {
-				gen.BindDelegationDesignator(v, tosca.ColdAccess)
+				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
 				gen.BindToAddressOfEmptyAccount(v)
 			},
 		},

--- a/go/ct/gen/accounts_test.go
+++ b/go/ct/gen/accounts_test.go
@@ -110,23 +110,23 @@ func TestAccountsGenerator_DelegationDesignatorCanBePrinted(t *testing.T) {
 		},
 		"delegate is cold": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
+				gen.BindToAddressOfDelegatingAccount(v, tosca.ColdAccess)
 			},
-			expected: "{isDelegated($v1), cold(delegateOf($v1))}",
+			expected: "{isDelegated($v1),cold(delegateOf($v1))}",
 		},
 		"delegate is warm": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
+				gen.BindToAddressOfDelegatingAccount(v, tosca.WarmAccess)
 			},
-			expected: "{isDelegated($v1), warm(delegateOf($v1))}",
+			expected: "{isDelegated($v1),warm(delegateOf($v1))}",
 		},
 		"is sorted": {
 			setup: func(gen *AccountsGenerator, v Variable) {
 				v2 := Variable("v2")
-				gen.BindToAddressOfDelegatedAccount(v2, tosca.WarmAccess)
+				gen.BindToAddressOfDelegatingAccount(v2, tosca.WarmAccess)
 				gen.BindNoDelegationDesignator(v)
 			},
-			expected: "{!isDelegated($v1),isDelegated($v2), warm(delegateOf($v2))}",
+			expected: "{!isDelegated($v1),isDelegated($v2),warm(delegateOf($v2))}",
 		},
 	}
 

--- a/go/ct/gen/accounts_test.go
+++ b/go/ct/gen/accounts_test.go
@@ -104,7 +104,7 @@ func TestAccountsGenerator_DelegationDesignatorCanBePrinted(t *testing.T) {
 	}{
 		"no delegation designator": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindNoDelegationDesignator(v)
+				gen.BindToAddressOfNotDelegatingAccount(v)
 			},
 			expected: "{!isDelegated($v1)}",
 		},
@@ -124,7 +124,7 @@ func TestAccountsGenerator_DelegationDesignatorCanBePrinted(t *testing.T) {
 			setup: func(gen *AccountsGenerator, v Variable) {
 				v2 := Variable("v2")
 				gen.BindToAddressOfDelegatingAccount(v2, tosca.WarmAccess)
-				gen.BindNoDelegationDesignator(v)
+				gen.BindToAddressOfNotDelegatingAccount(v)
 			},
 			expected: "{!isDelegated($v1),isDelegated($v2),warm(delegateOf($v2))}",
 		},
@@ -155,20 +155,20 @@ func TestAccountsGenerator_DelegationDesignatorConstraintsAreUsed(t *testing.T) 
 	}{
 		"no delegation designator": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindNoDelegationDesignator(v)
+				gen.BindToAddressOfNotDelegatingAccount(v)
 			},
 			withDelegate: false,
 		},
 		"delegate is cold": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
+				gen.BindToAddressOfDelegatingAccount(v, tosca.ColdAccess)
 			},
 			withDelegate: true,
 			access:       tosca.ColdAccess,
 		},
 		"delegate is warm": {
 			setup: func(gen *AccountsGenerator, v Variable) {
-				gen.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
+				gen.BindToAddressOfDelegatingAccount(v, tosca.WarmAccess)
 			},
 			withDelegate: true,
 			access:       tosca.WarmAccess,
@@ -231,25 +231,25 @@ func TestAccountsGenerator_DelegationDesignatorCanConflictWithOtherRules(t *test
 	}{
 		"disable and warm": {
 			constraint: func(gen *AccountsGenerator, v Variable) {
-				gen.BindNoDelegationDesignator(v)
-				gen.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
+				gen.BindToAddressOfNotDelegatingAccount(v)
+				gen.BindToAddressOfDelegatingAccount(v, tosca.WarmAccess)
 			},
 		},
 		"disable and cold": {
 			constraint: func(gen *AccountsGenerator, v Variable) {
-				gen.BindNoDelegationDesignator(v)
-				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
+				gen.BindToAddressOfNotDelegatingAccount(v)
+				gen.BindToAddressOfDelegatingAccount(v, tosca.ColdAccess)
 			},
 		},
 		"cold and warm": {
 			constraint: func(gen *AccountsGenerator, v Variable) {
-				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
-				gen.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
+				gen.BindToAddressOfDelegatingAccount(v, tosca.ColdAccess)
+				gen.BindToAddressOfDelegatingAccount(v, tosca.WarmAccess)
 			},
 		},
 		"empty and contains designator conflict": {
 			constraint: func(gen *AccountsGenerator, v Variable) {
-				gen.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
+				gen.BindToAddressOfDelegatingAccount(v, tosca.ColdAccess)
 				gen.BindToAddressOfEmptyAccount(v)
 			},
 		},

--- a/go/ct/gen/accounts_test.go
+++ b/go/ct/gen/accounts_test.go
@@ -523,42 +523,42 @@ func TestAccountsGenerator_DelegationDesignatorConstraint_CanBeSorted(t *testing
 
 	testValues := []*delegationDesignatorConstraint{
 		{
-			addressVariable:       Variable("v1"),
+			address:               Variable("v1"),
 			isDelegated:           false,
 			delegateAccountStatus: tosca.ColdAccess,
 		},
 		{
-			addressVariable:       Variable("v2"),
+			address:               Variable("v2"),
 			isDelegated:           false,
 			delegateAccountStatus: tosca.ColdAccess,
 		},
 		{
-			addressVariable:       Variable("v1"),
+			address:               Variable("v1"),
 			isDelegated:           true,
 			delegateAccountStatus: tosca.ColdAccess,
 		},
 		{
-			addressVariable:       Variable("v2"),
+			address:               Variable("v2"),
 			isDelegated:           true,
 			delegateAccountStatus: tosca.ColdAccess,
 		},
 		{
-			addressVariable:       Variable("v1"),
+			address:               Variable("v1"),
 			isDelegated:           false,
 			delegateAccountStatus: tosca.WarmAccess,
 		},
 		{
-			addressVariable:       Variable("v2"),
+			address:               Variable("v2"),
 			isDelegated:           false,
 			delegateAccountStatus: tosca.WarmAccess,
 		},
 		{
-			addressVariable:       Variable("v1"),
+			address:               Variable("v1"),
 			isDelegated:           true,
 			delegateAccountStatus: tosca.WarmAccess,
 		},
 		{
-			addressVariable:       Variable("v2"),
+			address:               Variable("v2"),
 			isDelegated:           true,
 			delegateAccountStatus: tosca.WarmAccess,
 		},

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -321,6 +321,13 @@ func (g *StateGenerator) IsAbsentBlobHashIndex(variable Variable) {
 	g.transactionContextGen.IsAbsentBlobHashIndex(variable)
 }
 
+func (g *StateGenerator) BindDelegationDesignator(address Variable, access tosca.AccessStatus) {
+	g.accountsGen.BindDelegationDesignator(address, access)
+}
+func (g *StateGenerator) BindNoDelegationDesignator(address Variable) {
+	g.accountsGen.BindNoDelegationDesignator(address)
+}
+
 // Generate produces a State instance satisfying the constraints set on this
 // generator or returns ErrUnsatisfiable on conflicting constraints. Subsequent
 // generators are invoked automatically.

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -321,10 +321,16 @@ func (g *StateGenerator) IsAbsentBlobHashIndex(variable Variable) {
 	g.transactionContextGen.IsAbsentBlobHashIndex(variable)
 }
 
-func (g *StateGenerator) BindDelegationDesignator(address Variable, access tosca.AccessStatus) {
-	g.accountsGen.BindDelegationDesignator(address, access)
+// BindToAddressOfDelegatedAccount constraints a variable to be bound to the
+// address of an account that is delegated, where the delegate address have
+// a defined AccessStatus.
+func (g *StateGenerator) BindToAddressOfDelegatedAccount(address Variable, delegateAccountStatus tosca.AccessStatus) {
+	g.accountsGen.BindToAddressOfDelegatedAccount(address, delegateAccountStatus)
 }
-func (g *StateGenerator) BindNoDelegationDesignator(address Variable) {
+
+// BindToAddressOfNotDelegatedAccount constraints a variable to be bound
+// to the address of an account that is not delegated.
+func (g *StateGenerator) BindToNotDelegatedAccount(address Variable) {
 	g.accountsGen.BindNoDelegationDesignator(address)
 }
 

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -321,17 +321,16 @@ func (g *StateGenerator) IsAbsentBlobHashIndex(variable Variable) {
 	g.transactionContextGen.IsAbsentBlobHashIndex(variable)
 }
 
-// BindToAddressOfDelegatedAccount constraints a variable to be bound to the
-// address of an account that is delegated, where the delegate address have
-// a defined AccessStatus.
-func (g *StateGenerator) BindToAddressOfDelegatedAccount(address Variable, delegateAccountStatus tosca.AccessStatus) {
-	g.accountsGen.BindToAddressOfDelegatedAccount(address, delegateAccountStatus)
+// BindToAddressOfDelegatingAccount constraints a variable to be bound to the
+// address of an account that is delegating, where the delegate have a defined AccessStatus.
+func (g *StateGenerator) BindToAddressOfDelegatingAccount(address Variable, delegateAccountStatus tosca.AccessStatus) {
+	g.accountsGen.BindToAddressOfDelegatingAccount(address, delegateAccountStatus)
 }
 
-// BindToAddressOfNotDelegatedAccount constraints a variable to be bound
-// to the address of an account that is not delegated.
-func (g *StateGenerator) BindToNotDelegatedAccount(address Variable) {
-	g.accountsGen.BindNoDelegationDesignator(address)
+// BindToAddressOfNotDelegatingAccount constraints a variable to be bound
+// to the address of an account that is not delegating.
+func (g *StateGenerator) BindToAddressOfNotDelegatingAccount(address Variable) {
+	g.accountsGen.BindToAddressOfNotDelegatingAccount(address)
 }
 
 // Generate produces a State instance satisfying the constraints set on this

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -1119,5 +1119,14 @@ func (c *containsDelegationDesignation) Restrict(*gen.StateGenerator) {
 }
 
 func (c *containsDelegationDesignation) String() string {
-	return fmt.Sprintf("%v containsDelegationDesignation", c.address)
+	switch c.state {
+	case NoDelegationDesignation:
+		return fmt.Sprintf("%v does not delegate code", c.address)
+	case WarmDelegationDesignation:
+		return fmt.Sprintf("%v is delegating code to a warm address", c.address)
+	case ColdDelegationDesignation:
+		return fmt.Sprintf("%v is delegating code to a cold address", c.address)
+	default:
+		return "unknown DelegationDesignatorState"
+	}
 }

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -1107,12 +1107,10 @@ func (c *containsDelegationDesignation) GetTestValues() []TestValue {
 			generator.BindDelegationDesignator(v, tosca.ColdAccess)
 		}
 	}
-	testValues := []TestValue{
-		NewTestValue(property, domain, NoDelegationDesignation, restrict),
-		NewTestValue(property, domain, WarnDelegationDesignation, restrict),
-		NewTestValue(property, domain, ColdDelegationDesignation, restrict),
+	return []TestValue{
+		NewTestValue(property, domain, c.state, restrict),
+		NewTestValue(property, domain, domain.SomethingNotEqual(c.state), restrict),
 	}
-	return testValues
 }
 
 func (c *containsDelegationDesignation) Restrict(*gen.StateGenerator) {

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -1083,7 +1083,7 @@ func (c *containsDelegationDesignation) Check(s *st.State) (bool, error) {
 	switch c.state {
 	case NoDelegationDesignation:
 		return !isDelegated, nil
-	case WarnDelegationDesignation:
+	case WarmDelegationDesignation:
 		return isDelegated && s.Accounts.IsWarm(delegateAddress), nil
 	case ColdDelegationDesignation:
 		return isDelegated && !s.Accounts.IsWarm(delegateAddress), nil
@@ -1102,7 +1102,7 @@ func (c *containsDelegationDesignation) GetTestValues() []TestValue {
 		switch state {
 		case NoDelegationDesignation:
 			generator.BindToAddressOfNotDelegatingAccount(v)
-		case WarnDelegationDesignation:
+		case WarmDelegationDesignation:
 			generator.BindToAddressOfDelegatingAccount(v, tosca.WarmAccess)
 		case ColdDelegationDesignation:
 			generator.BindToAddressOfDelegatingAccount(v, tosca.ColdAccess)

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -1087,8 +1087,9 @@ func (c *containsDelegationDesignation) Check(s *st.State) (bool, error) {
 		return isDelegated && s.Accounts.IsWarm(delegateAddress), nil
 	case ColdDelegationDesignation:
 		return isDelegated && !s.Accounts.IsWarm(delegateAddress), nil
+	default:
+		panic("unknown DelegationDesignatorState")
 	}
-	panic("unreachable")
 }
 
 func (c *containsDelegationDesignation) GetTestValues() []TestValue {

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -1054,7 +1054,7 @@ func (c *hasNoBlobHash) String() string {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// EIP 7702
+// callee account contains a delegation designator in code
 
 type containsDelegationDesignation struct {
 	address BindableExpression[U256]
@@ -1062,7 +1062,7 @@ type containsDelegationDesignation struct {
 }
 
 // DelegationDesignatorState is a condition where the Code of the account
-// at the given address has desigator to a warm delegate, a cold delegate or
+// at the given address has designator to a warm delegate, a cold delegate or
 // no delegate at all.
 // see https://eips.ethereum.org/EIPS/eip-7702
 func ConstraintDelegationDesignator(address BindableExpression[U256], state DelegationDesignatorState) Condition {

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -1101,11 +1101,11 @@ func (c *containsDelegationDesignation) GetTestValues() []TestValue {
 
 		switch state {
 		case NoDelegationDesignation:
-			generator.BindToNotDelegatedAccount(v)
+			generator.BindToAddressOfNotDelegatingAccount(v)
 		case WarnDelegationDesignation:
-			generator.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
+			generator.BindToAddressOfDelegatingAccount(v, tosca.WarmAccess)
 		case ColdDelegationDesignation:
-			generator.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
+			generator.BindToAddressOfDelegatingAccount(v, tosca.ColdAccess)
 		}
 	}
 	return []TestValue{

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -1101,11 +1101,11 @@ func (c *containsDelegationDesignation) GetTestValues() []TestValue {
 
 		switch state {
 		case NoDelegationDesignation:
-			generator.BindNoDelegationDesignator(v)
+			generator.BindToNotDelegatedAccount(v)
 		case WarnDelegationDesignation:
-			generator.BindDelegationDesignator(v, tosca.WarmAccess)
+			generator.BindToAddressOfDelegatedAccount(v, tosca.WarmAccess)
 		case ColdDelegationDesignation:
-			generator.BindDelegationDesignator(v, tosca.ColdAccess)
+			generator.BindToAddressOfDelegatedAccount(v, tosca.ColdAccess)
 		}
 	}
 	return []TestValue{

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -540,7 +540,7 @@ func TestCondition_DelegationDesignator_CanSetAddressStatus(t *testing.T) {
 	}
 
 	for _, status := range tests {
-		t.Run(DelegationDesignatorName(status), func(t *testing.T) {
+		t.Run(status.String(), func(t *testing.T) {
 
 			condition := ConstraintDelegationDesignator(Param(0), status)
 			var matchCovered, failCovered bool

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -535,7 +535,7 @@ func TestCondition_BlobHashesProducesGetTestValues(t *testing.T) {
 func TestCondition_DelegationDesignator_CanSetAddressStatus(t *testing.T) {
 	tests := []DelegationDesignatorState{
 		NoDelegationDesignation,
-		WarnDelegationDesignation,
+		WarmDelegationDesignation,
 		ColdDelegationDesignation,
 	}
 

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -532,6 +532,47 @@ func TestCondition_BlobHashesProducesGetTestValues(t *testing.T) {
 	}
 }
 
+func TestCondition_DelegationDesignator_CanSetAddressStatus(t *testing.T) {
+	tests := []DelegationDesignatorState{
+		NoDelegationDesignation,
+		WarnDelegationDesignation,
+		ColdDelegationDesignation,
+	}
+
+	for _, status := range tests {
+		t.Run(DelegationDesignatorName(status), func(t *testing.T) {
+
+			condition := ConstraintDelegationDesignator(Param(0), status)
+			var matchCovered, failCovered bool
+
+			for _, value := range condition.GetTestValues() {
+				gen := gen.NewStateGenerator()
+				value.Restrict(gen)
+
+				state, err := gen.Generate(rand.New(0))
+				if err != nil {
+					t.Fatalf("failed to build state: %v", err)
+				}
+
+				if matches, err := condition.Check(state); err != nil {
+					t.Errorf("failed to check condition: %v", err)
+				} else if matches {
+					matchCovered = true
+				} else {
+					failCovered = true
+				}
+			}
+
+			if !matchCovered {
+				t.Errorf("no test value matched the condition")
+			}
+			if !failCovered {
+				t.Errorf("no test value failed the condition")
+			}
+		})
+	}
+}
+
 func TestCondition_ConflictingAccountWarmConditionsAreUnsatisfiable(t *testing.T) {
 	isWarm := IsAddressWarm(Param(0))
 	isCold := IsAddressCold(Param(0))

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -434,7 +434,7 @@ type DelegationDesignatorState uint64
 
 const (
 	NoDelegationDesignation DelegationDesignatorState = iota
-	WarnDelegationDesignation
+	WarmDelegationDesignation
 	ColdDelegationDesignation
 )
 
@@ -442,8 +442,8 @@ func (dd DelegationDesignatorState) String() string {
 	switch dd {
 	case NoDelegationDesignation:
 		return "no_delegation_designation"
-	case WarnDelegationDesignation:
-		return "warn_delegation_designation"
+	case WarmDelegationDesignation:
+		return "warm_delegation_designation"
 	case ColdDelegationDesignation:
 		return "cold_delegation_designation"
 	}
@@ -484,7 +484,7 @@ func (d DelegationDesignatorDomain) Samples(DelegationDesignatorState) []Delegat
 func (DelegationDesignatorDomain) SamplesForAll([]DelegationDesignatorState) []DelegationDesignatorState {
 	return []DelegationDesignatorState{
 		NoDelegationDesignation,
-		WarnDelegationDesignation,
+		WarmDelegationDesignation,
 		ColdDelegationDesignation,
 	}
 }

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -422,3 +422,69 @@ func removeDuplicatesGeneric[T comparable](slice []T) []T {
 
 	return result
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Delegation designator domain
+
+// DelegationDesignatorState represents the state of a delegation designator in
+// the code of an account.
+// This type works together with ConstraintDelegationDesignator condition to model
+// EIP-7702 behavior.  see https://eips.ethereum.org/EIPS/eip-7702
+type DelegationDesignatorState = uint64
+
+const (
+	NoDelegationDesignation DelegationDesignatorState = iota
+	WarnDelegationDesignation
+	ColdDelegationDesignation
+)
+
+func DelegationDesignatorName(dd DelegationDesignatorState) string {
+	switch dd {
+	case NoDelegationDesignation:
+		return "no_delegate_designation"
+	case WarnDelegationDesignation:
+		return "warn_delegate_designation"
+	case ColdDelegationDesignation:
+		return "cold_delegate_designation"
+	}
+	return "unknown"
+}
+
+type DelegationDesignatorDomain struct{}
+
+func (DelegationDesignatorDomain) Equal(a DelegationDesignatorState, b DelegationDesignatorState) bool {
+	return a == b
+}
+
+func (DelegationDesignatorDomain) Less(a DelegationDesignatorState, b DelegationDesignatorState) bool {
+	return a < b
+}
+
+func (DelegationDesignatorDomain) Predecessor(a DelegationDesignatorState) DelegationDesignatorState {
+	// this domain cannot be used with Lt() nor Gt()
+	panic("not ordered")
+}
+
+func (DelegationDesignatorDomain) Successor(a DelegationDesignatorState) DelegationDesignatorState {
+	// this domain cannot be used with Lt() nor Gt()
+	panic("not ordered")
+}
+
+func (ddd DelegationDesignatorDomain) SomethingNotEqual(a DelegationDesignatorState) DelegationDesignatorState {
+	if a < ColdDelegationDesignation {
+		return a + 1
+	}
+	return NoDelegationDesignation
+}
+
+func (d DelegationDesignatorDomain) Samples(DelegationDesignatorState) []DelegationDesignatorState {
+	return d.SamplesForAll(nil)
+}
+
+func (DelegationDesignatorDomain) SamplesForAll([]DelegationDesignatorState) []DelegationDesignatorState {
+	return []DelegationDesignatorState{
+		NoDelegationDesignation,
+		WarnDelegationDesignation,
+		ColdDelegationDesignation,
+	}
+}

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -430,7 +430,7 @@ func removeDuplicatesGeneric[T comparable](slice []T) []T {
 // the code of an account.
 // This type works together with ConstraintDelegationDesignator condition to model
 // EIP-7702 behavior.  see https://eips.ethereum.org/EIPS/eip-7702
-type DelegationDesignatorState = uint64
+type DelegationDesignatorState uint64
 
 const (
 	NoDelegationDesignation DelegationDesignatorState = iota
@@ -438,7 +438,7 @@ const (
 	ColdDelegationDesignation
 )
 
-func DelegationDesignatorName(dd DelegationDesignatorState) string {
+func (dd DelegationDesignatorState) String() string {
 	switch dd {
 	case NoDelegationDesignation:
 		return "no_delegation_designation"

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -462,12 +462,12 @@ func (DelegationDesignatorDomain) Less(a DelegationDesignatorState, b Delegation
 
 func (DelegationDesignatorDomain) Predecessor(a DelegationDesignatorState) DelegationDesignatorState {
 	// this domain cannot be used with Lt() nor Gt()
-	panic("not ordered")
+	panic("not useful")
 }
 
 func (DelegationDesignatorDomain) Successor(a DelegationDesignatorState) DelegationDesignatorState {
 	// this domain cannot be used with Lt() nor Gt()
-	panic("not ordered")
+	panic("not useful")
 }
 
 func (ddd DelegationDesignatorDomain) SomethingNotEqual(a DelegationDesignatorState) DelegationDesignatorState {

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -441,11 +441,11 @@ const (
 func DelegationDesignatorName(dd DelegationDesignatorState) string {
 	switch dd {
 	case NoDelegationDesignation:
-		return "no_delegate_designation"
+		return "no_delegation_designation"
 	case WarnDelegationDesignation:
-		return "warn_delegate_designation"
+		return "warn_delegation_designation"
 	case ColdDelegationDesignation:
-		return "cold_delegate_designation"
+		return "cold_delegation_designation"
 	}
 	return "unknown"
 }

--- a/go/ct/rlz/domains_test.go
+++ b/go/ct/rlz/domains_test.go
@@ -518,6 +518,14 @@ func TestDomain_SamplesKnownValues(t *testing.T) {
 				math.MinInt64, -1, 0, 1, 255, 256, 257, math.MaxInt64, 22, 23, 24,
 			},
 		},
+		"delegation-designator-samples": {
+			got:  DelegationDesignatorDomain{}.Samples(NoDelegationDesignation),
+			want: []DelegationDesignatorState{NoDelegationDesignation, WarnDelegationDesignation, ColdDelegationDesignation},
+		},
+		"delegation-designator-samplesforall": {
+			got:  DelegationDesignatorDomain{}.SamplesForAll(nil),
+			want: []DelegationDesignatorState{NoDelegationDesignation, WarnDelegationDesignation, ColdDelegationDesignation},
+		},
 	}
 
 	for name, tc := range tests {

--- a/go/ct/rlz/domains_test.go
+++ b/go/ct/rlz/domains_test.go
@@ -520,11 +520,11 @@ func TestDomain_SamplesKnownValues(t *testing.T) {
 		},
 		"delegation-designator-samples": {
 			got:  DelegationDesignatorDomain{}.Samples(NoDelegationDesignation),
-			want: []DelegationDesignatorState{NoDelegationDesignation, WarnDelegationDesignation, ColdDelegationDesignation},
+			want: []DelegationDesignatorState{NoDelegationDesignation, WarmDelegationDesignation, ColdDelegationDesignation},
 		},
 		"delegation-designator-samplesforall": {
 			got:  DelegationDesignatorDomain{}.SamplesForAll([]DelegationDesignatorState{NoDelegationDesignation}),
-			want: []DelegationDesignatorState{NoDelegationDesignation, WarnDelegationDesignation, ColdDelegationDesignation},
+			want: []DelegationDesignatorState{NoDelegationDesignation, WarmDelegationDesignation, ColdDelegationDesignation},
 		},
 	}
 

--- a/go/ct/rlz/domains_test.go
+++ b/go/ct/rlz/domains_test.go
@@ -523,7 +523,7 @@ func TestDomain_SamplesKnownValues(t *testing.T) {
 			want: []DelegationDesignatorState{NoDelegationDesignation, WarnDelegationDesignation, ColdDelegationDesignation},
 		},
 		"delegation-designator-samplesforall": {
-			got:  DelegationDesignatorDomain{}.SamplesForAll(nil),
+			got:  DelegationDesignatorDomain{}.SamplesForAll([]DelegationDesignatorState{NoDelegationDesignation}),
 			want: []DelegationDesignatorState{NoDelegationDesignation, WarnDelegationDesignation, ColdDelegationDesignation},
 		},
 	}

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -2412,11 +2412,11 @@ func getRulesForAllCallTypes() []Rule {
 			for _, warm := range []bool{true, false} {
 				for _, static := range []bool{true, false} {
 					for _, zeroValue := range []bool{true, false} {
-						for _, DelegationDesignator := range []DelegationDesignatorState{NoDelegationDesignation, WarmDelegationDesignation, ColdDelegationDesignation} {
+						for _, delegationDesignator := range []DelegationDesignatorState{NoDelegationDesignation, WarmDelegationDesignation, ColdDelegationDesignation} {
 
 							// delegationDesignator is introduced in Prague; for any revision before, cold and warm cases
 							// are analogogus and half of them can be pruned.
-							if rev < tosca.R14_Prague && DelegationDesignator == ColdDelegationDesignation {
+							if rev < tosca.R14_Prague && delegationDesignator == ColdDelegationDesignation {
 								continue
 							}
 
@@ -2424,7 +2424,7 @@ func getRulesForAllCallTypes() []Rule {
 							if op == vm.CALL && static && !zeroValue {
 								effect = callFailEffect
 							}
-							res = append(res, getRulesForCall(op, rev, warm, zeroValue, DelegationDesignator, effect, static)...)
+							res = append(res, getRulesForCall(op, rev, warm, zeroValue, delegationDesignator, effect, static)...)
 						}
 					}
 				}
@@ -2435,7 +2435,7 @@ func getRulesForAllCallTypes() []Rule {
 	return res
 }
 
-func getRulesForCall(op vm.OpCode, revision tosca.Revision, warm, zeroValue bool, DelegationDesignator DelegationDesignatorState, opEffect func(s *st.State, addrAccessCost tosca.Gas, op vm.OpCode), static bool) []Rule {
+func getRulesForCall(op vm.OpCode, revision tosca.Revision, warm, zeroValue bool, delegationDesignator DelegationDesignatorState, opEffect func(s *st.State, addrAccessCost tosca.Gas, op vm.OpCode), static bool) []Rule {
 
 	var staticGas tosca.Gas
 	if revision == tosca.R07_Istanbul {
@@ -2483,7 +2483,7 @@ func getRulesForCall(op vm.OpCode, revision tosca.Revision, warm, zeroValue bool
 		IsRevision(revision),
 		targetWarm,
 		staticCondition,
-		ConstraintDelegationDesignator(Param(1), DelegationDesignator),
+		ConstraintDelegationDesignator(Param(1), delegationDesignator),
 	}
 
 	var valueZeroCondition Condition
@@ -2520,7 +2520,7 @@ func getRulesForCall(op vm.OpCode, revision tosca.Revision, warm, zeroValue bool
 		warmColdString,
 		staticConditionName,
 		valueZeroConditionName,
-		DelegationDesignator.String(),
+		delegationDesignator.String(),
 	}, "_")
 	name = strings.Replace(name, "__", "_", -1)
 

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -2413,6 +2413,13 @@ func getRulesForAllCallTypes() []Rule {
 				for _, static := range []bool{true, false} {
 					for _, zeroValue := range []bool{true, false} {
 						for _, DelegationDesignator := range []DelegationDesignatorState{NoDelegationDesignation, WarnDelegationDesignation, ColdDelegationDesignation} {
+
+							// delegationDesignator is introduced in Prague; for any revision before, cold and warm cases
+							// are analogogus and half of them can be pruned.
+							if rev < tosca.R14_Prague && DelegationDesignator == ColdDelegationDesignation {
+								continue
+							}
+
 							effect := callEffect
 							if op == vm.CALL && static && !zeroValue {
 								effect = callFailEffect
@@ -2515,6 +2522,7 @@ func getRulesForCall(op vm.OpCode, revision tosca.Revision, warm, zeroValue bool
 		valueZeroConditionName,
 		DelegationDesignatorName(DelegationDesignator),
 	}, "_")
+	name = strings.Replace(name, "__", "_", -1)
 
 	return rulesFor(instruction{
 		op:         op,

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -2520,7 +2520,7 @@ func getRulesForCall(op vm.OpCode, revision tosca.Revision, warm, zeroValue bool
 		warmColdString,
 		staticConditionName,
 		valueZeroConditionName,
-		DelegationDesignatorName(DelegationDesignator),
+		DelegationDesignator.String(),
 	}, "_")
 	name = strings.Replace(name, "__", "_", -1)
 

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -2412,7 +2412,7 @@ func getRulesForAllCallTypes() []Rule {
 			for _, warm := range []bool{true, false} {
 				for _, static := range []bool{true, false} {
 					for _, zeroValue := range []bool{true, false} {
-						for _, DelegationDesignator := range []DelegationDesignatorState{NoDelegationDesignation, WarnDelegationDesignation, ColdDelegationDesignation} {
+						for _, DelegationDesignator := range []DelegationDesignatorState{NoDelegationDesignation, WarmDelegationDesignation, ColdDelegationDesignation} {
 
 							// delegationDesignator is introduced in Prague; for any revision before, cold and warm cases
 							// are analogogus and half of them can be pruned.


### PR DESCRIPTION
[EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) introduces a small change on dynamic costs for all four call interpreter instructions. 

This PR is organized by commits, visiting one commit at the time is recommended for review. 

**The EIP change:**
- The delegation-designator is a 23 byte slice which consists of the `0xef, 0x01, 0x00` prefix and a target account address (the delegate account).
- The delegation-designator is to be stored in the code storage of the account pointed by the second parameter of a call instruction, instead of a valid opcodes slice. 
-  Any call operation, finding a delegation-designator in the code storage of the address being called, needs to charge EIP-2929 gas costs based in the warm/cold status of the delegation address. 

This PR adds CT support to construct the states affected by these changes and the conditions to identify the inputs that exploit them. 

This PR increase the CT test count from 25507439914 to 228720519466  (~10 times). The change in state count influences CT execution time, and Unit test time. The later may not run anymore within the 10 minutes expectation.  

- [x] Run CT
- [x] Decide on viability of test count increment.
- [x] Improve unit test execution time. 
