### PR TITLE
CT: refactor json and string output

### DIFF
--- a/go/ct/common/bytes.go
+++ b/go/ct/common/bytes.go
@@ -14,6 +14,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"pgregory.net/rand"
 )
@@ -48,11 +49,14 @@ func (b Bytes) ToBytes() []byte {
 }
 
 func (b Bytes) String() string {
-	return fmt.Sprintf("0x%x", b.data)
+	if len(b.data) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("0x%x", b.ToBytes())
 }
 
 func (b Bytes) MarshalJSON() ([]byte, error) {
-	return json.Marshal(fmt.Sprintf("%x", b.ToBytes()))
+	return json.Marshal(b.String())
 }
 
 func (b *Bytes) UnmarshalJSON(data []byte) error {
@@ -60,6 +64,7 @@ func (b *Bytes) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
+	s = strings.TrimPrefix(s, "0x")
 	data, err := hex.DecodeString(s)
 	if err != nil {
 		return err

--- a/go/ct/common/bytes_test.go
+++ b/go/ct/common/bytes_test.go
@@ -54,10 +54,10 @@ func TestBytes_CanBeJsonEncoded(t *testing.T) {
 			NewBytes(nil), "\"\"",
 		},
 		"single": {
-			NewBytes([]byte{1}), "\"01\"",
+			NewBytes([]byte{1}), "\"0x01\"",
 		},
 		"triple": {
-			NewBytes([]byte{1, 2, 3}), "\"010203\"",
+			NewBytes([]byte{1, 2, 3}), "\"0x010203\"",
 		},
 	}
 
@@ -122,7 +122,7 @@ func TestBytes_String(t *testing.T) {
 	if b.String() != "0x010203" {
 		t.Errorf("unexpected string representation, got %v", b.String())
 	}
-	if NewBytes([]byte{}).String() != "0x" {
+	if NewBytes([]byte{}).String() != "" {
 		t.Errorf("unexpected string representation, got %v", Bytes{}.String())
 	}
 }

--- a/go/ct/st/serialization_test.go
+++ b/go/ct/st/serialization_test.go
@@ -335,11 +335,11 @@ func TestSerialization_byteSliceMarshal(t *testing.T) {
 		slice    Bytes
 		expected string
 	}{
-		{NewBytes([]byte{byte(0x01)}), "\"01\""},
-		{NewBytes([]byte{byte(0xff)}), "\"ff\""},
-		{NewBytes([]byte{byte(0x01), byte(0x02), byte(0x03), byte(0x04), byte(0x05), byte(0x06)}), "\"010203040506\""},
-		{NewBytes([]byte{byte(0xfa), byte(0xfb), byte(0xfc), byte(0xfd), byte(0xfe), byte(0xff)}), "\"fafbfcfdfeff\""},
-		{NewBytes([]byte{byte(0x01), byte(0x23), byte(0x45), byte(0x67), byte(0x89), byte(0xab)}), "\"0123456789ab\""},
+		{NewBytes([]byte{byte(0x01)}), "\"0x01\""},
+		{NewBytes([]byte{byte(0xff)}), "\"0xff\""},
+		{NewBytes([]byte{byte(0x01), byte(0x02), byte(0x03), byte(0x04), byte(0x05), byte(0x06)}), "\"0x010203040506\""},
+		{NewBytes([]byte{byte(0xfa), byte(0xfb), byte(0xfc), byte(0xfd), byte(0xfe), byte(0xff)}), "\"0xfafbfcfdfeff\""},
+		{NewBytes([]byte{byte(0x01), byte(0x23), byte(0x45), byte(0x67), byte(0x89), byte(0xab)}), "\"0x0123456789ab\""},
 	}
 
 	for _, test := range tests {
@@ -358,11 +358,11 @@ func TestSerialization_byteSliceUnmarshal(t *testing.T) {
 		input    string
 		expected Bytes
 	}{
-		{"\"01\"", NewBytes([]byte{byte(0x01)})},
-		{"\"ff\"", NewBytes([]byte{byte(0xff)})},
-		{"\"010203040506\"", NewBytes([]byte{byte(0x01), byte(0x02), byte(0x03), byte(0x04), byte(0x05), byte(0x06)})},
-		{"\"fafbfcfdfeff\"", NewBytes([]byte{byte(0xfa), byte(0xfb), byte(0xfc), byte(0xfd), byte(0xfe), byte(0xff)})},
-		{"\"0123456789ab\"", NewBytes([]byte{byte(0x01), byte(0x23), byte(0x45), byte(0x67), byte(0x89), byte(0xab)})},
+		{"\"0x01\"", NewBytes([]byte{byte(0x01)})},
+		{"\"0xff\"", NewBytes([]byte{byte(0xff)})},
+		{"\"0x010203040506\"", NewBytes([]byte{byte(0x01), byte(0x02), byte(0x03), byte(0x04), byte(0x05), byte(0x06)})},
+		{"\"0xfafbfcfdfeff\"", NewBytes([]byte{byte(0xfa), byte(0xfb), byte(0xfc), byte(0xfd), byte(0xfe), byte(0xff)})},
+		{"\"0x0123456789ab\"", NewBytes([]byte{byte(0x01), byte(0x23), byte(0x45), byte(0x67), byte(0x89), byte(0xab)})},
 	}
 
 	for _, test := range tests {

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -52,6 +52,7 @@ func getNewFilledState() *State {
 	s.BlockContext = BlockContext{BlockNumber: 1}
 	s.TransactionContext = &TransactionContext{BlobHashes: []tosca.Hash{{4, 3, 2, 1}}}
 	s.CallData = NewBytes([]byte{1})
+	s.ReturnData = NewBytes([]byte{2})
 	s.LastCallReturnData = NewBytes([]byte{1})
 	s.HasSelfDestructed = true
 	s.SelfDestructedJournal = []SelfDestructEntry{{tosca.Address{1}, tosca.Address{2}}}


### PR DESCRIPTION
The `Bytes`' type string and json output lead to some confusion in the past. The `String` and `MarshalJSON` methods have been unified.
The input state has been printed twice in case of a failure.
Clarification which value is from the CT and which from the interpreter under test has been added.