### PR TITLE
evmzero: Add eip-7702 delegation designation cost

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -10,6 +10,7 @@
 
 #include "vm/evmzero/interpreter.h"
 
+#include <array>
 #include <bit>
 #include <cstdint>
 #include <cstdio>
@@ -1726,6 +1727,22 @@ struct CallImpl {
         }
       }
 
+      // EIP-7702 delegation designation warm/cold access cost
+      int64_t delegation_designation_cost = 0;
+      if (ctx.revision >= EVMC_PRAGUE) {
+        constexpr size_t kDelegationDesignationSize = 23;
+        std::array<uint8_t, kDelegationDesignationSize + 1> code;
+        size_t code_size = ctx.host->copy_code(account, 0, code.begin(), code.size());
+        if (code_size == kDelegationDesignationSize && code[0] == 0xef && code[1] == 0x01 && code[2] == 0x00) {
+          auto target = reinterpret_cast<evmc_address*>(&(code[3]));
+          if (ctx.host->access_account(*target) == EVMC_ACCESS_WARM) {
+            delegation_designation_cost = 100;
+          } else {
+            delegation_designation_cost = 2600;
+          }
+        }
+      }
+
       int64_t positive_value_cost = has_value ? 9000 : 0;
       int64_t value_to_empty_account_cost = 0;
       if constexpr (Op != op::CALLCODE) {
@@ -1734,7 +1751,8 @@ struct CallImpl {
         }
       }
 
-      if (gas -= address_access_cost + positive_value_cost + value_to_empty_account_cost; gas < 0) [[unlikely]]
+      if (gas -= address_access_cost + delegation_designation_cost + positive_value_cost + value_to_empty_account_cost;
+          gas < 0) [[unlikely]]
         return {.dynamic_gas_costs = initial_gas - gas};
     }
 

--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1731,6 +1731,7 @@ struct CallImpl {
       int64_t delegation_designation_cost = 0;
       if (ctx.revision >= EVMC_PRAGUE) {
         constexpr size_t kDelegationDesignationSize = 23;
+        // Copy one extra byte to check if the code is exactly 23 bytes long.
         std::array<uint8_t, kDelegationDesignationSize + 1> code;
         size_t code_size = ctx.host->copy_code(account, 0, code.begin(), code.size());
         if (code_size == kDelegationDesignationSize && code[0] == 0xef && code[1] == 0x01 && code[2] == 0x00) {

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -14,9 +14,11 @@
 #include <gtest/gtest.h>
 
 #include <evmc/evmc.hpp>
+#include <iterator>
 
 #include "evmc/evmc.h"
 #include "vm/evmzero/opcodes.h"
+#include "vm/evmzero/uint256.h"
 
 namespace tosca::evmzero {
 namespace {
@@ -5318,6 +5320,72 @@ TEST(InterpreterTest, CALL_NoZeroPaddingForCallResult) {
           0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,  //
       },
       .host = &host,
+  });
+}
+
+TEST(InterpreterTest, CALL_NoDelegationDesignationChargesPrePrague) {
+  const uint256_t destination = 0x42;
+  const evmc::address destination_adr = evmc::address(destination[0]);
+  const evmc::address target = evmc::address(0x24);
+  std::vector<uint8_t> code = {0xef, 0x01, 0x00};
+  code.insert(code.end(), std::begin(target.bytes), std::end(target.bytes));
+
+  MockHost host;
+  EXPECT_CALL(host, access_account(destination_adr)).WillOnce(Return(EVMC_ACCESS_WARM));
+  EXPECT_CALL(host, call(_)).WillOnce(Return(evmc::Result(EVMC_SUCCESS)));
+
+  RunInterpreterTest({
+      .code = {op::CALL},
+      .gas_before = 50000,
+      .gas_after = 50000 - 100,
+      .stack_before =
+          {
+              0x00,         // < ret_size
+              0x00,         // < ret_offset
+              0x00,         // < arg_size
+              0x00,         // < arg_offset
+              0x00,         // < value
+              destination,  // < address
+              0,            // < gas
+          },
+      .stack_after = {0x01},
+      .host = &host,
+      .revision = EVMC_CANCUN,
+  });
+}
+
+TEST(InterpreterTest, CALL_PragueChargesForDelegationDesignation) {
+  const uint256_t destination = 0x42;
+  const evmc::address destination_adr = evmc::address(destination[0]);
+  const evmc::address target = evmc::address(0x24);
+  std::vector<uint8_t> code = {0xef, 0x01, 0x00};
+  code.insert(code.end(), std::begin(target.bytes), std::end(target.bytes));
+
+  MockHost host;
+  EXPECT_CALL(host, access_account(destination_adr)).WillOnce(Return(EVMC_ACCESS_WARM));
+  EXPECT_CALL(host, copy_code(destination_adr, 0, _, 24))  //
+      .Times(1)
+      .WillOnce(DoAll(SetArrayArgument<2>(code.data(), code.data() + 23), Return(23)));
+  EXPECT_CALL(host, access_account(target)).WillOnce(Return(EVMC_ACCESS_WARM));
+  EXPECT_CALL(host, call(_)).WillOnce(Return(evmc::Result(EVMC_SUCCESS)));
+
+  RunInterpreterTest({
+      .code = {op::CALL},
+      .gas_before = 50000,
+      .gas_after = 50000 - 100 - 100,
+      .stack_before =
+          {
+              0x00,         // < ret_size
+              0x00,         // < ret_offset
+              0x00,         // < arg_size
+              0x00,         // < arg_offset
+              0x00,         // < value
+              destination,  // < address
+              0,            // < gas
+          },
+      .stack_after = {0x01},
+      .host = &host,
+      .revision = EVMC_PRAGUE,
   });
 }
 

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -5361,32 +5361,39 @@ TEST(InterpreterTest, CALL_PragueChargesForDelegationDesignation) {
   std::vector<uint8_t> code = {0xef, 0x01, 0x00};
   code.insert(code.end(), std::begin(target.bytes), std::end(target.bytes));
 
-  MockHost host;
-  EXPECT_CALL(host, access_account(destination_adr)).WillOnce(Return(EVMC_ACCESS_WARM));
-  EXPECT_CALL(host, copy_code(destination_adr, 0, _, 24))  //
-      .Times(1)
-      .WillOnce(DoAll(SetArrayArgument<2>(code.data(), code.data() + 23), Return(23)));
-  EXPECT_CALL(host, access_account(target)).WillOnce(Return(EVMC_ACCESS_WARM));
-  EXPECT_CALL(host, call(_)).WillOnce(Return(evmc::Result(EVMC_SUCCESS)));
+  for (const auto access_status : {EVMC_ACCESS_WARM, EVMC_ACCESS_COLD}) {
+    MockHost host;
+    EXPECT_CALL(host, access_account(destination_adr)).WillOnce(Return(EVMC_ACCESS_WARM));
+    EXPECT_CALL(host, copy_code(destination_adr, 0, _, 24))  //
+        .Times(1)
+        .WillOnce(DoAll(SetArrayArgument<2>(code.data(), code.data() + 23), Return(23)));
+    EXPECT_CALL(host, access_account(target)).WillOnce(Return(access_status));
+    EXPECT_CALL(host, call(_)).WillOnce(Return(evmc::Result(EVMC_SUCCESS)));
 
-  RunInterpreterTest({
-      .code = {op::CALL},
-      .gas_before = 50000,
-      .gas_after = 50000 - 100 - 100,
-      .stack_before =
-          {
-              0x00,         // < ret_size
-              0x00,         // < ret_offset
-              0x00,         // < arg_size
-              0x00,         // < arg_offset
-              0x00,         // < value
-              destination,  // < address
-              0,            // < gas
-          },
-      .stack_after = {0x01},
-      .host = &host,
-      .revision = EVMC_PRAGUE,
-  });
+    int access_cost = 100;
+    if (access_status == EVMC_ACCESS_COLD) {
+      access_cost = 2600;
+    }
+
+    RunInterpreterTest({
+        .code = {op::CALL},
+        .gas_before = 50000,
+        .gas_after = 50000 - 100 - access_cost,
+        .stack_before =
+            {
+                0x00,         // < ret_size
+                0x00,         // < ret_offset
+                0x00,         // < arg_size
+                0x00,         // < arg_offset
+                0x00,         // < value
+                destination,  // < address
+                0,            // < gas
+            },
+        .stack_after = {0x01},
+        .host = &host,
+        .revision = EVMC_PRAGUE,
+    });
+  }
 }
 
 ///////////////////////////////////////////////////////////

--- a/go/interpreter/evmzero/evmzero.go
+++ b/go/interpreter/evmzero/evmzero.go
@@ -116,7 +116,7 @@ type evmzeroInstance struct {
 	e *evmc.EvmcInterpreter
 }
 
-const newestSupportedRevision = tosca.R13_Cancun
+const newestSupportedRevision = tosca.R14_Prague
 
 func (e *evmzeroInstance) Run(params tosca.Parameters) (tosca.Result, error) {
 	if params.Revision > newestSupportedRevision {


### PR DESCRIPTION
This PR adds the delegation designation billing to the `evmzero`. With these changes, the interpreter now fully supports the Prague revision.

- [x] Unit tests
- [x] updated CT run