### PR TITLE
Finalize Prague update

### DIFF
--- a/go/ct/common/revisions.go
+++ b/go/ct/common/revisions.go
@@ -18,7 +18,7 @@ import (
 
 // Newest tosca.Revision currently supported by the CT specification
 const NewestSupportedRevision = tosca.R14_Prague
-const NewestFullySupportedRevision = tosca.R13_Cancun
+const NewestFullySupportedRevision = tosca.R14_Prague
 
 const R99_UnknownNextRevision = tosca.Revision(99)
 const MinRevision = tosca.R07_Istanbul

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -553,6 +553,7 @@ func TestRunContextAdapter_bigIntToWord(t *testing.T) {
 }
 
 func TestRunContextAdapter_ConvertRevision(t *testing.T) {
+	pragueTime := uint64(1100)
 	cancunTime := uint64(1000)
 	shanghaiTime := uint64(900)
 	parisBlock := big.NewInt(100)
@@ -599,6 +600,12 @@ func TestRunContextAdapter_ConvertRevision(t *testing.T) {
 			time:   cancunTime,
 			want:   tosca.R13_Cancun,
 		},
+		"Prague": {
+			random: &gc.Hash{0x42},
+			block:  parisBlock,
+			time:   pragueTime,
+			want:   tosca.R14_Prague,
+		},
 	}
 
 	chainConfig := &params.ChainConfig{
@@ -609,6 +616,7 @@ func TestRunContextAdapter_ConvertRevision(t *testing.T) {
 		MergeNetsplitBlock: parisBlock,
 		ShanghaiTime:       &shanghaiTime,
 		CancunTime:         &cancunTime,
+		PragueTime:         &pragueTime,
 	}
 
 	for name, test := range tests {

--- a/go/interpreter/evmone/evmone.go
+++ b/go/interpreter/evmone/evmone.go
@@ -57,7 +57,7 @@ type evmoneInstance struct {
 	e *evmc.EvmcInterpreter
 }
 
-const newestSupportedRevision = tosca.R13_Cancun
+const newestSupportedRevision = tosca.R14_Prague
 
 func (e *evmoneInstance) Run(params tosca.Parameters) (tosca.Result, error) {
 	if params.Revision > newestSupportedRevision {

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -74,6 +74,7 @@ func TestContext_isAtLeast_RespectsOrderOfRevisions(t *testing.T) {
 		tosca.R11_Paris,
 		tosca.R12_Shanghai,
 		tosca.R13_Cancun,
+		tosca.R14_Prague,
 	}
 
 	for _, is := range revisions {

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -175,10 +175,14 @@ func blockParametersToChainConfig(blockParams tosca.BlockParameters) *params.Cha
 	zeroTime := uint64(0)
 	chainConfig.ShanghaiTime = &zeroTime
 	chainConfig.CancunTime = &zeroTime
+	chainConfig.PragueTime = &zeroTime
 
 	greaterBlockTime := uint64(blockParams.Timestamp + 1)
 	greaterBlockNumber := big.NewInt(blockParams.BlockNumber + 1)
 
+	if blockParams.Revision < tosca.R14_Prague {
+		chainConfig.PragueTime = &greaterBlockTime
+	}
 	if blockParams.Revision < tosca.R13_Cancun {
 		chainConfig.CancunTime = &greaterBlockTime
 	}

--- a/go/processor/geth/processor_test.go
+++ b/go/processor/geth/processor_test.go
@@ -54,6 +54,11 @@ func TestGethProcessor_RevisionConversion(t *testing.T) {
 			timestamp:   200,
 			revision:    tosca.R13_Cancun,
 		},
+		"Prague": {
+			blockNumber: 7000,
+			timestamp:   300,
+			revision:    tosca.R14_Prague,
+		},
 	}
 
 	for name, test := range tests {
@@ -67,7 +72,8 @@ func TestGethProcessor_RevisionConversion(t *testing.T) {
 			chainConfig := blockParametersToChainConfig(toscaBlockParameters)
 			rules := chainConfig.Rules(big.NewInt(test.blockNumber), test.revision >= tosca.R11_Paris, uint64(test.timestamp))
 
-			if ((test.revision >= tosca.R13_Cancun) != rules.IsCancun) ||
+			if ((test.revision >= tosca.R14_Prague) != rules.IsPrague) ||
+				((test.revision >= tosca.R13_Cancun) != rules.IsCancun) ||
 				((test.revision >= tosca.R12_Shanghai) != rules.IsShanghai) ||
 				((test.revision >= tosca.R11_Paris) != rules.IsMerge) ||
 				((test.revision >= tosca.R10_London) != rules.IsLondon) ||

--- a/go/tosca/vm/opcodes_test.go
+++ b/go/tosca/vm/opcodes_test.go
@@ -79,7 +79,7 @@ func TestOpCode_NumberOfOpCodes(t *testing.T) {
 		CREATE, CALL, CALLCODE, RETURN, DELEGATECALL, CREATE2, STATICCALL, REVERT, INVALID, SELFDESTRUCT,
 		BASEFEE,                                     // London
 		PUSH0,                                       // Shanghai
-		BLOBHASH, BLOBBASEFEE, TLOAD, TSTORE, MCOPY, // Cancun
+		BLOBHASH, BLOBBASEFEE, TLOAD, TSTORE, MCOPY, // Cancun, Prague
 	}
 
 	for i := 0; i < 256; i++ {


### PR DESCRIPTION
This PR adds the last required changes to support the Prague revision in tosca.
Some unit test where extended and `evmone` has been updated to [v0.14.0](https://github.com/ethereum/evmone/releases/tag/v0.14.0). The `evmone` update has been tested by running tosca's interpreter integration tests.