### PR TITLE
evmrs: remove feature fn-ptr-conversion-inline-dispatch

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -60,7 +60,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo clippy
       working-directory: rust
-      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable clippy --all-targets -- --deny warnings
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable clippy --all-targets -- --deny warnings
     
   doc:
     name: doc
@@ -81,7 +81,7 @@ jobs:
       env:
         RUSTDOCFLAGS: "-D warnings" 
       working-directory: rust
-      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable doc --no-deps
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable doc --no-deps
 
   build:
     name: build
@@ -100,7 +100,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo build
       working-directory: rust
-      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable build
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable build
 
   test:
     name: test
@@ -119,7 +119,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo test
       working-directory: rust
-      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable test
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable test
     - name: cargo test tail call elimination
       working-directory: rust
       run: cargo test --profile release --features tail-call
@@ -145,18 +145,18 @@ jobs:
       working-directory: rust
       env:
         RUSTFLAGS: -Zsanitizer=address
-      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable test -Zbuild-std --target x86_64-unknown-linux-gnu
+      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable test -Zbuild-std --target x86_64-unknown-linux-gnu
     - name: cargo test with memory sanitizer
       working-directory: rust
       env:
         RUSTFLAGS: "-Zsanitizer=memory -Zsanitizer-memory-track-origins"
-      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable test -Zbuild-std --target x86_64-unknown-linux-gnu
+      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable test -Zbuild-std --target x86_64-unknown-linux-gnu
     - name: cargo test with thread sanitizer
       working-directory: rust
       env:
         CFLAGS: -fsanitize=thread
         RUSTFLAGS: -Zsanitizer=thread
-      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable test -Zbuild-std --target x86_64-unknown-linux-gnu
+      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable test -Zbuild-std --target x86_64-unknown-linux-gnu
 
   benchmarks-with-sanitizers:
     name: benchmarks-with-sanitizers
@@ -213,7 +213,7 @@ jobs:
       working-directory: rust
       env: 
         MIRIFLAGS: "-Zmiri-disable-stacked-borrows -Zmiri-permissive-provenance -Zmiri-backtrace=full"
-      run: cargo +nightly hack miri test --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable,mimalloc,performance
+      run: cargo +nightly hack miri test --workspace --each-feature --exclude-features needs-cache,needs-jumptable,mimalloc,performance
     - name: cargo miri benchmarks
       working-directory: rust
       env: 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,7 +21,6 @@ mock = ["dep:mockall"]
 fuzzing = ["dep:arbitrary"]
 # partial features (enabled by other features to simplify conditional compilation attributes. Not intended to be used on their own)
 needs-jumptable = []
-needs-fn-ptr-conversion = ["needs-jumptable"]
 needs-cache = ["dep:lru"]
 # optimizations:
 performance = [
@@ -32,7 +31,7 @@ performance = [
     "hash-cache",
     "code-analysis-cache",
     "alloc-reuse",
-    "fn-ptr-conversion-expanded-dispatch",
+    "fn-ptr-conversion-dispatch",
 ]
 mimalloc = ["dep:mimalloc"]
 unsafe-stack = []
@@ -43,10 +42,9 @@ code-analysis-cache = ["dep:nohash-hasher", "needs-cache"]
 alloc-reuse = []
 tail-call = []
 # function/ opcode dispatch:
-# feature precedence: switch-dispatch (default) < jumptable-dispatch < fn-ptr-conversion-inline-dispatch < fn-ptr-conversion-expanded-dispatch
+# feature precedence: switch-dispatch (default) < jumptable-dispatch < fn-ptr-conversion-dispatch
 jumptable-dispatch = ["needs-jumptable"]
-fn-ptr-conversion-inline-dispatch = ["needs-fn-ptr-conversion"]
-fn-ptr-conversion-expanded-dispatch = ["needs-fn-ptr-conversion"]
+fn-ptr-conversion-dispatch = ["needs-jumptable"]
 
 [dependencies]
 bnum = "0.12.0"

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -13,10 +13,7 @@ code-analysis-cache = ["evmrs/code-analysis-cache"]
 alloc-reuse = ["evmrs/alloc-reuse"]
 tail-call = ["evmrs/tail-call"]
 jumptable-dispatch = ["evmrs/jumptable-dispatch"]
-fn-ptr-conversion-expanded-dispatch = [
-    "evmrs/fn-ptr-conversion-expanded-dispatch",
-]
-fn-ptr-conversion-inline-dispatch = ["evmrs/fn-ptr-conversion-inline-dispatch"]
+fn-ptr-conversion-dispatch = ["evmrs/fn-ptr-conversion-dispatch"]
 
 [dependencies]
 evmrs = { path = ".." }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,24 +16,13 @@ compile_error!(
 );
 
 #[cfg(all(
-    feature = "needs-fn-ptr-conversion",
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    not(feature = "fn-ptr-conversion-inline-dispatch"),
-))]
-compile_error!(
-    "Feature `needs-fn-ptr-conversion` is only a helper feature and not supposed to be enabled on its own.
-    Either disable it or enable one or all of `fn-ptr-conversion-expanded-dispatch` or `fn-ptr-conversion-inline-dispatch`."
-);
-
-#[cfg(all(
     feature = "needs-jumptable",
     not(feature = "jumptable-dispatch"),
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    not(feature = "fn-ptr-conversion-inline-dispatch"),
+    not(feature = "fn-ptr-conversion-dispatch"),
 ))]
 compile_error!(
     "Feature `needs-jumptable` is only a helper feature and not supposed to be enabled on its own.
-    Either disable it or enable one or all of `jumptable-dispatch`, `fn-ptr-conversion-expanded-dispatch` or `fn-ptr-conversion-inline-dispatch`."
+    Either disable it or enable one or all of `jumptable-dispatch` or `fn-ptr-conversion-dispatch`."
 );
 
 #[cfg(not(feature = "custom-evmc"))]

--- a/rust/src/types/code_analysis.rs
+++ b/rust/src/types/code_analysis.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "needs-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-dispatch")]
 use std::cmp::min;
 #[cfg(feature = "code-analysis-cache")]
 use std::sync::Arc;
@@ -9,12 +9,7 @@ use nohash_hasher::BuildNoHashHasher;
 #[cfg(feature = "code-analysis-cache")]
 use crate::types::Cache;
 use crate::types::{code_byte_type, u256, CodeByteType};
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-use crate::types::{op_fn_data::OP_FN_DATA_SIZE, Opcode};
-#[cfg(feature = "needs-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-dispatch")]
 use crate::types::{OpFnData, PcMap};
 #[cfg(feature = "code-analysis-cache")]
 use crate::utils::GetGenericStatic;
@@ -38,17 +33,20 @@ pub type AnalysisContainer<T> = T;
 #[cfg(feature = "code-analysis-cache")]
 pub type AnalysisContainer<T> = Arc<T>;
 
-#[cfg(not(feature = "needs-fn-ptr-conversion"))]
+#[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
 pub type AnalysisItem<const STEPPABLE: bool> = CodeByteType;
-#[cfg(feature = "needs-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-dispatch")]
 pub type AnalysisItem<const STEPPABLE: bool> = OpFnData<STEPPABLE>;
 
 #[cfg(all(
     feature = "code-analysis-cache",
-    not(feature = "needs-fn-ptr-conversion")
+    not(feature = "fn-ptr-conversion-dispatch")
 ))]
 const CACHE_SIZE: usize = 1 << 16; // value taken from evmzero
-#[cfg(all(feature = "code-analysis-cache", feature = "needs-fn-ptr-conversion"))]
+#[cfg(all(
+    feature = "code-analysis-cache",
+    feature = "fn-ptr-conversion-dispatch"
+))]
 // 48B for OpFnData + 2*8B for entries in PcMap = 64B -> reduce size from 2^16 to 2^16 / 64 = 2^10
 // to keep roughly the same memory size
 const CACHE_SIZE: usize = 1 << 10;
@@ -79,7 +77,7 @@ impl GetGenericStatic for GenericCodeAnalysisCache {
 #[derive(Debug)]
 pub struct CodeAnalysis<const STEPPABLE: bool> {
     pub analysis: Vec<AnalysisItem<STEPPABLE>>,
-    #[cfg(feature = "needs-fn-ptr-conversion")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     pub pc_map: PcMap,
 }
 
@@ -98,7 +96,7 @@ impl<const STEPPABLE: bool> CodeAnalysis<STEPPABLE> {
         Self::analyze_code(code)
     }
 
-    #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+    #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     fn analyze_code(code: &[u8]) -> Self {
         let mut code_byte_types = vec![CodeByteType::DataOrInvalid; code.len()];
 
@@ -113,7 +111,7 @@ impl<const STEPPABLE: bool> CodeAnalysis<STEPPABLE> {
             analysis: code_byte_types,
         }
     }
-    #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     fn analyze_code(code: &[u8]) -> Self {
         let mut analysis = Vec::with_capacity(code.len());
         // +32+1 because if last op is push32 we need mapping from after converted to after code+32
@@ -164,102 +162,17 @@ impl<const STEPPABLE: bool> CodeAnalysis<STEPPABLE> {
 
         CodeAnalysis { analysis, pc_map }
     }
-    #[cfg(all(
-        not(feature = "fn-ptr-conversion-expanded-dispatch"),
-        feature = "fn-ptr-conversion-inline-dispatch"
-    ))]
-    fn analyze_code(code: &[u8]) -> Self {
-        let mut analysis = Vec::with_capacity(code.len());
-        // +32+1 because if last op is push32 we need mapping from after converted to after code+32
-        let mut pc_map = PcMap::new(code.len() + 32 + 1);
-
-        let mut pc = 0;
-        let mut no_ops = 0;
-        while let Some(op) = code.get(pc).copied() {
-            let (code_byte_type, mut data_len) = code_byte_type(op);
-
-            pc += 1;
-            match code_byte_type {
-                CodeByteType::JumpDest => {
-                    pc_map.add_mapping(pc - 1, analysis.len());
-                    match no_ops {
-                        0 => (),
-                        1 => analysis.push(OpFnData::func(Opcode::NoOp as u8)),
-                        2.. => analysis.extend(OpFnData::skip_no_ops_iter(no_ops)),
-                    }
-                    no_ops = 0;
-                    analysis.push(OpFnData::jump_dest());
-                    pc_map.add_mapping(pc - 1, analysis.len() - 1);
-                }
-                CodeByteType::Push => {
-                    analysis.push(OpFnData::func(op));
-                    pc_map.add_mapping(pc - 1, analysis.len() - 1);
-
-                    let mut capped_inc = data_len.rem_euclid(OP_FN_DATA_SIZE);
-                    if capped_inc == 0 {
-                        capped_inc = OP_FN_DATA_SIZE;
-                    }
-                    let data = copy_push_data(code, pc, capped_inc);
-                    analysis.push(OpFnData::data(data));
-                    no_ops += capped_inc - 1;
-                    data_len -= capped_inc;
-                    pc += capped_inc;
-
-                    while data_len > 0 {
-                        let capped_inc = min(data_len, OP_FN_DATA_SIZE);
-                        let data = copy_push_data(code, pc, capped_inc);
-                        analysis.push(OpFnData::data(data));
-                        no_ops += capped_inc - 1;
-                        data_len -= capped_inc;
-                        pc += capped_inc;
-                    }
-                }
-                CodeByteType::Opcode => {
-                    analysis.push(OpFnData::func(op));
-                    pc_map.add_mapping(pc - 1, analysis.len() - 1);
-                }
-                CodeByteType::DataOrInvalid => {
-                    // This should only be the case if an invalid opcode was not preceded by a push.
-                    // In this case we don't care what the data contains.
-                    analysis.push(OpFnData::data([0; OP_FN_DATA_SIZE]));
-                    pc_map.add_mapping(pc - 1, analysis.len() - 1);
-                }
-            };
-        }
-
-        pc_map.add_mapping(pc, analysis.len()); // in case pc points past code (this is valid)
-
-        CodeAnalysis { analysis, pc_map }
-    }
-}
-
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-fn copy_push_data(src: &[u8], src_start: usize, len: usize) -> [u8; OP_FN_DATA_SIZE] {
-    let src = &src[min(src.len(), src_start)..];
-    let len = min(len, OP_FN_DATA_SIZE);
-    let mut data = [0; OP_FN_DATA_SIZE];
-    let copy = min(len, src.len());
-    data[OP_FN_DATA_SIZE - len..OP_FN_DATA_SIZE - len + copy].copy_from_slice(&src[..copy]);
-    data
 }
 
 #[cfg(test)]
 mod tests {
-    #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+    #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     use crate::types::CodeByteType;
-    #[cfg(all(
-        not(feature = "fn-ptr-conversion-expanded-dispatch"),
-        feature = "fn-ptr-conversion-inline-dispatch"
-    ))]
-    use crate::types::{op_fn_data::OP_FN_DATA_SIZE, OpFnData};
-    #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     use crate::types::{u256, OpFnData};
     use crate::types::{CodeAnalysis, Opcode};
 
-    #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+    #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     #[test]
     fn analyze_code_single_byte() {
         assert_eq!(
@@ -280,7 +193,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     #[test]
     fn analyze_code_single_byte() {
         assert_eq!(
@@ -300,34 +213,7 @@ mod tests {
             [OpFnData::data(u256::ZERO)]
         );
     }
-    #[cfg(all(
-        not(feature = "fn-ptr-conversion-expanded-dispatch"),
-        feature = "fn-ptr-conversion-inline-dispatch"
-    ))]
-    #[test]
-    fn analyze_code_single_byte() {
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[Opcode::Add as u8]).analysis,
-            [OpFnData::<false>::func(Opcode::Add as u8)]
-        );
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[Opcode::Push2 as u8]).analysis,
-            [
-                OpFnData::<false>::func(Opcode::Push2 as u8),
-                OpFnData::data([0; OP_FN_DATA_SIZE])
-            ]
-        );
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[Opcode::JumpDest as u8]).analysis,
-            [OpFnData::jump_dest()]
-        );
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[0xc0]).analysis,
-            [OpFnData::data([0; OP_FN_DATA_SIZE])]
-        );
-    }
-
-    #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+    #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     #[test]
     fn analyze_code_jumpdest() {
         assert_eq!(
@@ -341,7 +227,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     #[test]
     fn analyze_code_jumpdest() {
         use crate::u256;
@@ -359,26 +245,8 @@ mod tests {
             [OpFnData::jump_dest(), OpFnData::data(u256::ZERO)]
         );
     }
-    #[cfg(all(
-        not(feature = "fn-ptr-conversion-expanded-dispatch"),
-        feature = "fn-ptr-conversion-inline-dispatch"
-    ))]
-    #[test]
-    fn analyze_code_jumpdest() {
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[Opcode::JumpDest as u8, Opcode::Add as u8])
-                .analysis,
-            [
-                OpFnData::jump_dest(),
-                OpFnData::<false>::func(Opcode::Add as u8)
-            ]
-        );
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[Opcode::JumpDest as u8, 0xc0]).analysis,
-            [OpFnData::jump_dest(), OpFnData::data([0; OP_FN_DATA_SIZE])]
-        );
-    }
-    #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+
+    #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     #[test]
     fn analyze_code_push_with_data() {
         assert_eq!(
@@ -449,8 +317,7 @@ mod tests {
             ]
         );
     }
-
-    #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     #[test]
     fn analyze_code_push_with_data() {
         use crate::u256;
@@ -535,120 +402,6 @@ mod tests {
                 ),
                 OpFnData::<false>::func(Opcode::Add as u8, u256::ZERO),
             ]
-        );
-    }
-    #[cfg(all(
-        not(feature = "fn-ptr-conversion-expanded-dispatch"),
-        feature = "fn-ptr-conversion-inline-dispatch"
-    ))]
-    #[test]
-    fn analyze_code_push_with_data() {
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[
-                Opcode::Push1 as u8,
-                Opcode::Add as u8,
-                Opcode::Add as u8
-            ])
-            .analysis,
-            [
-                OpFnData::<false>::func(Opcode::Push1 as u8,),
-                OpFnData::data([0, 0, 0, Opcode::Add as u8]),
-                OpFnData::<false>::func(Opcode::Add as u8),
-            ]
-        );
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[Opcode::Push1 as u8, Opcode::Add as u8, 0xc0])
-                .analysis,
-            [
-                OpFnData::<false>::func(Opcode::Push1 as u8,),
-                OpFnData::data([0, 0, 0, Opcode::Add as u8]),
-                OpFnData::data([0; OP_FN_DATA_SIZE]),
-            ]
-        );
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[
-                Opcode::Push1 as u8,
-                Opcode::Add as u8,
-                0xc0,
-                Opcode::Add as u8
-            ])
-            .analysis,
-            [
-                OpFnData::<false>::func(Opcode::Push1 as u8,),
-                OpFnData::data([0, 0, 0, Opcode::Add as u8]),
-                OpFnData::data([0; OP_FN_DATA_SIZE]),
-                OpFnData::<false>::func(Opcode::Add as u8),
-            ]
-        );
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[
-                Opcode::Push2 as u8,
-                Opcode::Add as u8,
-                Opcode::Add as u8,
-                Opcode::Add as u8,
-            ])
-            .analysis,
-            [
-                OpFnData::<false>::func(Opcode::Push2 as u8,),
-                OpFnData::data([0, 0, Opcode::Add as u8, Opcode::Add as u8]),
-                OpFnData::<false>::func(Opcode::Add as u8),
-            ]
-        );
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&[
-                Opcode::Push2 as u8,
-                Opcode::Add as u8,
-                Opcode::Add as u8,
-                0xc0
-            ])
-            .analysis,
-            [
-                OpFnData::<false>::func(Opcode::Push2 as u8,),
-                OpFnData::data([0, 0, Opcode::Add as u8, Opcode::Add as u8]),
-                OpFnData::data([0; OP_FN_DATA_SIZE]),
-            ]
-        );
-        let mut code = [1; 23];
-        code[0] = Opcode::Push21 as u8;
-        code[1] = 2;
-        code[21] = 3;
-        code[22] = Opcode::Add as u8;
-        assert_eq!(
-            CodeAnalysis::<false>::analyze_code(&code).analysis,
-            [
-                OpFnData::<false>::func(Opcode::Push21 as u8),
-                OpFnData::data([0, 0, 0, 2]),
-                OpFnData::data([1, 1, 1, 1]),
-                OpFnData::data([1, 1, 1, 1]),
-                OpFnData::data([1, 1, 1, 1]),
-                OpFnData::data([1, 1, 1, 1]),
-                OpFnData::data([1, 1, 1, 3]),
-                OpFnData::<false>::func(Opcode::Add as u8),
-            ]
-        );
-    }
-
-    #[cfg(all(
-        not(feature = "fn-ptr-conversion-expanded-dispatch"),
-        feature = "fn-ptr-conversion-inline-dispatch"
-    ))]
-    #[test]
-    fn copy_push_data() {
-        assert_eq!(super::copy_push_data(&[], 0, 0), [0; OP_FN_DATA_SIZE]);
-        assert_eq!(super::copy_push_data(&[], 0, 1), [0; OP_FN_DATA_SIZE]);
-        assert_eq!(super::copy_push_data(&[], 1, 0), [0; OP_FN_DATA_SIZE]);
-        assert_eq!(super::copy_push_data(&[], 1, 1), [0; OP_FN_DATA_SIZE]);
-        assert_eq!(super::copy_push_data(&[1, 2, 3], 0, 2), [0, 0, 1, 2]);
-        assert_eq!(super::copy_push_data(&[1, 2, 3], 1, 2), [0, 0, 2, 3]);
-        assert_eq!(super::copy_push_data(&[1, 2, 3], 1, 3), [0, 2, 3, 0]);
-        assert_eq!(super::copy_push_data(&[1, 2, 3], 1, 1), [0, 0, 0, 2]);
-        assert_eq!(
-            super::copy_push_data(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1, 4),
-            [2, 3, 4, 5]
-        );
-        assert_eq!(
-            super::copy_push_data(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1, 100),
-            [2, 3, 4, 5]
         );
     }
 }

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -1,22 +1,17 @@
-#[cfg(not(feature = "needs-fn-ptr-conversion"))]
+#[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
 use std::cmp::min;
 use std::{self, ops::Deref};
 
-#[cfg(feature = "needs-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-dispatch")]
 use crate::interpreter::OpFn;
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-use crate::types::op_fn_data::OP_FN_DATA_SIZE;
-#[cfg(not(feature = "needs-fn-ptr-conversion"))]
+#[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
 use crate::types::Opcode;
 use crate::types::{u256, AnalysisContainer, CodeAnalysis, CodeByteType, FailStatus};
 
-#[cfg(not(feature = "fn-ptr-conversion-expanded-dispatch"))]
+#[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
 struct PushDataLen<const N: usize>;
 
-#[cfg(not(feature = "fn-ptr-conversion-expanded-dispatch"))]
+#[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
 impl<const N: usize> PushDataLen<N> {
     const VALID: () = assert!(N > 0 && N <= 32);
 }
@@ -45,7 +40,7 @@ pub enum GetOpcodeError {
 impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
     pub fn new(code: &'a [u8], code_hash: Option<u256>, pc: usize) -> Self {
         let code_analysis = CodeAnalysis::new(code, code_hash);
-        #[cfg(feature = "needs-fn-ptr-conversion")]
+        #[cfg(feature = "fn-ptr-conversion-dispatch")]
         let pc = code_analysis.pc_map.to_converted(pc);
         Self {
             code,
@@ -54,7 +49,7 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
         }
     }
 
-    #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+    #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     pub fn get(&self) -> Result<Opcode, GetOpcodeError> {
         if let Some(op) = self.code.get(self.pc) {
             let analysis = self.code_analysis.analysis[self.pc];
@@ -72,7 +67,7 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
             Err(GetOpcodeError::OutOfRange)
         }
     }
-    #[cfg(feature = "needs-fn-ptr-conversion")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     pub fn get(&self) -> Result<OpFn<STEPPABLE>, GetOpcodeError> {
         self.code_analysis
             .analysis
@@ -88,10 +83,10 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
     pub fn try_jump(&mut self, dest: u256) -> Result<(), FailStatus> {
         let dest = u64::try_from(dest).map_err(|_| FailStatus::BadJumpDestination)? as usize;
         if !self.code_analysis.analysis.get(dest).is_some_and(|c| {
-            #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+            #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
             return *c == CodeByteType::JumpDest;
 
-            #[cfg(feature = "needs-fn-ptr-conversion")]
+            #[cfg(feature = "fn-ptr-conversion-dispatch")]
             return c.code_byte_type() == CodeByteType::JumpDest;
         }) {
             return Err(FailStatus::BadJumpDestination);
@@ -101,7 +96,7 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
         Ok(())
     }
 
-    #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+    #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     pub fn get_push_data<const N: usize>(&mut self) -> u256 {
         let () = const { PushDataLen::<N>::VALID };
 
@@ -113,7 +108,7 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
 
         data
     }
-    #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     pub fn get_push_data(&mut self) -> u256 {
         // SAFETY:
         // This assertion assumes that the program counter (self.pc) was not modified after calling
@@ -131,42 +126,22 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
         self.pc += 1;
         res
     }
-    #[cfg(all(
-        not(feature = "fn-ptr-conversion-expanded-dispatch"),
-        feature = "fn-ptr-conversion-inline-dispatch"
-    ))]
-    pub fn get_push_data<const N: usize>(&mut self) -> u256 {
-        const MAX_CHUNKS: usize = 32usize.div_ceil(OP_FN_DATA_SIZE);
 
-        let () = const { PushDataLen::<N>::VALID };
-
-        let mut data = [0; 32];
-        let chunks = const { N.div_ceil(OP_FN_DATA_SIZE) };
-        for chunk in 0..chunks {
-            let offset = (MAX_CHUNKS - chunks + chunk) * OP_FN_DATA_SIZE;
-            data[offset..offset + OP_FN_DATA_SIZE]
-                .copy_from_slice(&self.code_analysis.analysis[self.pc].get_data());
-            self.pc += 1;
-        }
-
-        u256::from_be_bytes(data)
-    }
-
-    #[cfg(feature = "needs-fn-ptr-conversion")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     pub fn jump_to(&mut self) {
-        #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
+        #[cfg(feature = "fn-ptr-conversion-dispatch")]
         let offset = self.code_analysis.analysis[self.pc]
             .get_data()
             .into_u64_saturating();
-        #[cfg(not(feature = "fn-ptr-conversion-expanded-dispatch"))]
+        #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
         let offset = u32::from_ne_bytes(self.code_analysis.analysis[self.pc].get_data());
         self.pc += offset as usize;
     }
 
     pub fn pc(&self) -> usize {
-        #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+        #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
         return self.pc;
-        #[cfg(feature = "needs-fn-ptr-conversion")]
+        #[cfg(feature = "fn-ptr-conversion-dispatch")]
         return self.code_analysis.pc_map.to_ct(self.pc);
     }
 }
@@ -188,7 +163,7 @@ mod tests {
         assert_eq!(code_reader.pc(), pc);
     }
 
-    #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     #[test]
     fn code_reader_pc() {
         let code = [Opcode::Push1 as u8, Opcode::Add as u8, Opcode::Add as u8];
@@ -222,47 +197,6 @@ mod tests {
 
         let code_reader = CodeReader::<false>::new(&code, None, 22);
         assert_eq!(code_reader.pc, 1);
-        assert_eq!(code_reader.pc(), 22);
-    }
-    #[cfg(all(
-        not(feature = "fn-ptr-conversion-expanded-dispatch"),
-        feature = "fn-ptr-conversion-inline-dispatch"
-    ))]
-    #[test]
-    fn code_reader_pc() {
-        let code = [Opcode::Push1 as u8, Opcode::Add as u8, Opcode::Add as u8];
-
-        let code_reader = CodeReader::<false>::new(&code, None, 0);
-        assert_eq!(code_reader.pc, 0);
-        assert_eq!(code_reader.pc(), 0);
-
-        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
-        assert_eq!(code_reader.pc, 0);
-        code_reader.next();
-        code_reader.get_push_data::<1>();
-        assert_eq!(code_reader.pc, 2);
-        assert_eq!(code_reader.pc(), 2);
-
-        let code_reader = CodeReader::<false>::new(&code, None, 2);
-        assert_eq!(code_reader.pc, 2);
-        assert_eq!(code_reader.pc(), 2);
-
-        let mut code = [Opcode::Add as u8; 23];
-        code[0] = Opcode::Push21 as u8;
-
-        let code_reader = CodeReader::<false>::new(&code, None, 0);
-        assert_eq!(code_reader.pc, 0);
-        assert_eq!(code_reader.pc(), 0);
-
-        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
-        assert_eq!(code_reader.pc, 0);
-        code_reader.next();
-        code_reader.get_push_data::<21>();
-        assert_eq!(code_reader.pc, 7);
-        assert_eq!(code_reader.pc(), 22);
-
-        let code_reader = CodeReader::<false>::new(&code, None, 22);
-        assert_eq!(code_reader.pc, 7);
         assert_eq!(code_reader.pc(), 22);
     }
 
@@ -270,14 +204,14 @@ mod tests {
     fn code_reader_get() {
         let mut code_reader =
             CodeReader::<false>::new(&[Opcode::Add as u8, Opcode::Add as u8, 0xc0], None, 0);
-        #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+        #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
         assert_eq!(code_reader.get(), Ok(Opcode::Add));
-        #[cfg(feature = "needs-fn-ptr-conversion")]
+        #[cfg(feature = "fn-ptr-conversion-dispatch")]
         assert!(code_reader.get().is_ok(),);
         code_reader.next();
-        #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+        #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
         assert_eq!(code_reader.get(), Ok(Opcode::Add));
-        #[cfg(feature = "needs-fn-ptr-conversion")]
+        #[cfg(feature = "fn-ptr-conversion-dispatch")]
         assert!(code_reader.get().is_ok(),);
         code_reader.next();
         assert_eq!(code_reader.get(), Err(GetOpcodeError::Invalid));
@@ -311,7 +245,7 @@ mod tests {
         );
     }
 
-    #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+    #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     #[test]
     fn code_reader_get_push_data() {
         let mut code_reader = CodeReader::<false>::new(&[0xff; 32], None, 0);
@@ -329,7 +263,7 @@ mod tests {
         let mut code_reader = CodeReader::<false>::new(&[0xff; 32], None, 32);
         assert_eq!(code_reader.get_push_data::<32>(), u256::ZERO);
     }
-    #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     #[test]
     fn code_reader_get_push_data() {
         // pc on data is non longer possible because there are not data items anymore
@@ -337,24 +271,5 @@ mod tests {
         code[0] = Opcode::Push32 as u8;
         let mut code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.get_push_data(), u256::MAX);
-    }
-    #[cfg(all(
-        not(feature = "fn-ptr-conversion-expanded-dispatch"),
-        feature = "fn-ptr-conversion-inline-dispatch"
-    ))]
-    #[test]
-    fn code_reader_get_push_data() {
-        // data is only treated as such if it comes after a push
-        // pc on data is undefined behavior so we have to advance the pc by calling next
-        let mut code = [0xff; 33];
-        code[0] = Opcode::Push32 as u8;
-
-        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
-        code_reader.next();
-        assert_eq!(code_reader.get_push_data::<1>(), (u32::MAX as u64).into());
-
-        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
-        code_reader.next();
-        assert_eq!(code_reader.get_push_data::<32>(), u256::MAX);
     }
 }

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -8,10 +8,10 @@ pub mod hash_cache;
 mod memory;
 mod mock_execution_message;
 mod observer;
-#[cfg(feature = "needs-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-dispatch")]
 mod op_fn_data;
 mod opcode;
-#[cfg(feature = "needs-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-dispatch")]
 mod pc_map;
 mod stack;
 mod status_code;
@@ -26,10 +26,10 @@ pub use execution_context::*;
 pub use memory::Memory;
 pub use mock_execution_message::MockExecutionMessage;
 pub use observer::*;
-#[cfg(feature = "needs-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-dispatch")]
 pub use op_fn_data::OpFnData;
 pub use opcode::*;
-#[cfg(feature = "needs-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-dispatch")]
 pub use pc_map::PcMap;
 pub use stack::Stack;
 pub use status_code::{ExecStatus, FailStatus};

--- a/rust/src/types/observer.rs
+++ b/rust/src/types/observer.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, io::Write};
 
 use crate::interpreter::Interpreter;
-#[cfg(feature = "needs-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-dispatch")]
 use crate::Opcode;
 
 pub trait Observer<const STEPPABLE: bool> {
@@ -35,9 +35,9 @@ impl<W: Write> LoggingObserver<W> {
 impl<W: Write, const STEPPABLE: bool> Observer<STEPPABLE> for LoggingObserver<W> {
     fn pre_op(&mut self, interpreter: &Interpreter<STEPPABLE>) {
         // pre_op is called after the op is fetched so this will always be Ok(..)
-        #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+        #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
         let op = interpreter.code_reader.get().unwrap();
-        #[cfg(feature = "needs-fn-ptr-conversion")]
+        #[cfg(feature = "fn-ptr-conversion-dispatch")]
         let op = {
             let op = interpreter.code_reader[interpreter.code_reader.pc()];
             // SAFETY:

--- a/rust/src/types/op_fn_data.rs
+++ b/rust/src/types/op_fn_data.rs
@@ -1,147 +1,19 @@
 use std::fmt::Debug;
 
-#[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
-use crate::u256;
 use crate::{
     interpreter::{GenericJumptable, OpFn},
     types::CodeByteType,
+    u256,
     utils::GetGenericStatic,
     Opcode,
 };
 
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-pub const OP_FN_DATA_SIZE: usize = 4;
-
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-#[derive(Debug, PartialEq, Eq)]
-#[repr(u8)]
-enum OpFnDataType {
-    Opcode = 0,
-    JumpDest = 1,
-    DataOrInvalid = 2,
-}
-
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-#[derive(Clone, PartialEq, Eq)]
-#[repr(align(8))]
-pub struct OpFnData<const STEPPABLE: bool> {
-    raw: *const (),
-}
-
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-// SAFETY:
-// OpFnData only stores function pointers or [u8; 4] so it is safe to share across threads;
-unsafe impl<const STEPPABLE: bool> Send for OpFnData<STEPPABLE> {}
-
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-// SAFETY:
-// OpFnData only stores function pointers or [u8; 4] so it is safe to share across threads;
-unsafe impl<const STEPPABLE: bool> Sync for OpFnData<STEPPABLE> {}
-
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-impl<const STEPPABLE: bool> OpFnData<STEPPABLE> {
-    pub fn data(data: [u8; OP_FN_DATA_SIZE]) -> Self {
-        // assumes native endian = little endian
-        let mut raw = [0; 8];
-        raw[..OP_FN_DATA_SIZE].copy_from_slice(&data);
-        raw[7] = OpFnDataType::DataOrInvalid as u8;
-
-        Self {
-            raw: usize::from_ne_bytes(raw) as *const (),
-        }
-    }
-
-    pub fn skip_no_ops_iter(count: usize) -> impl Iterator<Item = Self> {
-        let skip_no_ops = Self::func(Opcode::SkipNoOps as u8);
-        let count_data = Self::data((count as u32).to_ne_bytes());
-        let gen_no_ops = move || Self::func(Opcode::NoOp as u8);
-        std::iter::once(skip_no_ops)
-            .chain(std::iter::once(count_data))
-            .chain(std::iter::repeat_with(gen_no_ops).take(count - 2))
-    }
-
-    pub fn func(op: u8) -> Self {
-        OpFnData {
-            raw: GenericJumptable::get::<STEPPABLE>()[op as usize] as *const (),
-        }
-    }
-
-    pub fn jump_dest() -> Self {
-        let mut ptr_value =
-            GenericJumptable::get::<STEPPABLE>()[Opcode::JumpDest as u8 as usize] as usize;
-        ptr_value |= 0x0100000000000000; // OpFnDataType::JumpDest
-        Self {
-            raw: ptr_value as *const (),
-        }
-    }
-
-    pub fn code_byte_type(&self) -> CodeByteType {
-        match (self.raw as usize).to_ne_bytes()[7] {
-            t if t == OpFnDataType::Opcode as u8 => CodeByteType::Opcode,
-            t if t == OpFnDataType::JumpDest as u8 => CodeByteType::JumpDest,
-            _ => CodeByteType::DataOrInvalid,
-        }
-    }
-
-    pub fn get_func(&self) -> Option<OpFn<STEPPABLE>> {
-        if (self.raw as usize).to_ne_bytes()[7] == OpFnDataType::DataOrInvalid as u8 {
-            None
-        } else {
-            let mut ptr_value = self.raw as usize;
-            ptr_value &= 0x0000ffffffffffff;
-            let ptr = ptr_value as *const ();
-            // SAFETY:
-            // During code analysis self.raw was created from a function pointer. The highest bit
-            // was used for marking it as such, but was masked out. As long as only the lower 6
-            // bytes are used for pointers, the value is the same as before the conversion.
-            Some(unsafe { std::mem::transmute::<*const (), OpFn<STEPPABLE>>(ptr) })
-        }
-    }
-
-    pub fn get_data(&self) -> [u8; OP_FN_DATA_SIZE] {
-        // SAFETY:
-        // A pointer to an 8 byte array can be safely cast to a pointer to an 4 byte and then read
-        // as such, because the alignment is the same and all reads are in bounds.
-        unsafe { std::ptr::read(&self.raw as *const _ as *const [u8; OP_FN_DATA_SIZE]) }
-    }
-}
-
-#[cfg(all(
-    not(feature = "fn-ptr-conversion-expanded-dispatch"),
-    feature = "fn-ptr-conversion-inline-dispatch"
-))]
-impl<const STEPPABLE: bool> Debug for OpFnData<STEPPABLE> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpFnData").field("raw", &self.raw).finish()
-    }
-}
-
-#[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
 #[derive(Clone, PartialEq, Eq)]
 pub struct OpFnData<const STEPPABLE: bool> {
     func: Option<OpFn<STEPPABLE>>,
     data: u256,
 }
 
-#[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
 impl<const STEPPABLE: bool> OpFnData<STEPPABLE> {
     pub fn data(data: u256) -> Self {
         Self { func: None, data }
@@ -183,7 +55,6 @@ impl<const STEPPABLE: bool> OpFnData<STEPPABLE> {
     }
 }
 
-#[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
 impl<const STEPPABLE: bool> Debug for OpFnData<STEPPABLE> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpFnData")

--- a/rust/src/types/opcode.rs
+++ b/rust/src/types/opcode.rs
@@ -178,9 +178,9 @@ pub enum Opcode {
     Shr = SHR,
     Sar = SAR,
     Sha3 = SHA3,
-    #[cfg(feature = "needs-fn-ptr-conversion")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     NoOp = SHA3 + 1,
-    #[cfg(feature = "needs-fn-ptr-conversion")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     SkipNoOps = SHA3 + 2,
     Address = ADDRESS,
     Balance = BALANCE,
@@ -309,7 +309,7 @@ pub enum Opcode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodeByteType {
     JumpDest,
-    #[cfg(feature = "needs-fn-ptr-conversion")]
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
     Push,
     Opcode,
     DataOrInvalid,
@@ -331,9 +331,9 @@ pub fn code_byte_type(code_byte: u8) -> (CodeByteType, usize) {
         | LOG4 | CREATE | CALL | CALLCODE | RETURN | DELEGATECALL | CREATE2 | STATICCALL
         | REVERT | INVALID | SELFDESTRUCT => (CodeByteType::Opcode, 0),
         PUSH1..=PUSH32 => (
-            #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+            #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
             CodeByteType::Opcode,
-            #[cfg(feature = "needs-fn-ptr-conversion")]
+            #[cfg(feature = "fn-ptr-conversion-dispatch")]
             CodeByteType::Push,
             (code_byte - Opcode::Push1 as u8 + 1) as usize,
         ),


### PR DESCRIPTION
This PR removes the `fn-ptr-conversion-inline-dispatch` feature.
`fn-ptr-conversion-inline-dispatch` is slower than `fn-ptr-conversion-expanded-dispatch`, more complicated and requires unsafe code.
Additionally, `fn-ptr-conversion-expanded-dispatch` is renamed to `fn-ptr-conversion-dispatch` because it is now the only dispatch doing conversion during the code analysis. Because of that, the helper feature `needs-fn-ptr-conversoion` also be removed.