### PR TITLE
evmrs: remove switch dispatch and make jumptable dispatch the default

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -60,7 +60,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo clippy
       working-directory: rust
-      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable clippy --all-targets -- --deny warnings
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache clippy --all-targets -- --deny warnings
     
   doc:
     name: doc
@@ -81,7 +81,7 @@ jobs:
       env:
         RUSTDOCFLAGS: "-D warnings" 
       working-directory: rust
-      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable doc --no-deps
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache doc --no-deps
 
   build:
     name: build
@@ -100,7 +100,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo build
       working-directory: rust
-      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable build
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache build
 
   test:
     name: test
@@ -119,7 +119,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo test
       working-directory: rust
-      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable test
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache test
     - name: cargo test tail call elimination
       working-directory: rust
       run: cargo test --profile release --features tail-call
@@ -145,18 +145,18 @@ jobs:
       working-directory: rust
       env:
         RUSTFLAGS: -Zsanitizer=address
-      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable test -Zbuild-std --target x86_64-unknown-linux-gnu
+      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache test -Zbuild-std --target x86_64-unknown-linux-gnu
     - name: cargo test with memory sanitizer
       working-directory: rust
       env:
         RUSTFLAGS: "-Zsanitizer=memory -Zsanitizer-memory-track-origins"
-      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable test -Zbuild-std --target x86_64-unknown-linux-gnu
+      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache test -Zbuild-std --target x86_64-unknown-linux-gnu
     - name: cargo test with thread sanitizer
       working-directory: rust
       env:
         CFLAGS: -fsanitize=thread
         RUSTFLAGS: -Zsanitizer=thread
-      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache,needs-jumptable test -Zbuild-std --target x86_64-unknown-linux-gnu
+      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache test -Zbuild-std --target x86_64-unknown-linux-gnu
 
   benchmarks-with-sanitizers:
     name: benchmarks-with-sanitizers
@@ -213,7 +213,7 @@ jobs:
       working-directory: rust
       env: 
         MIRIFLAGS: "-Zmiri-disable-stacked-borrows -Zmiri-permissive-provenance -Zmiri-backtrace=full"
-      run: cargo +nightly hack miri test --workspace --each-feature --exclude-features needs-cache,needs-jumptable,mimalloc,performance
+      run: cargo +nightly hack miri test --workspace --each-feature --exclude-features needs-cache,mimalloc,performance
     - name: cargo miri benchmarks
       working-directory: rust
       env: 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,6 @@ default = []
 mock = ["dep:mockall"]
 fuzzing = ["dep:arbitrary"]
 # partial features (enabled by other features to simplify conditional compilation attributes. Not intended to be used on their own)
-needs-jumptable = []
 needs-cache = ["dep:lru"]
 # optimizations:
 performance = [
@@ -42,9 +41,8 @@ code-analysis-cache = ["dep:nohash-hasher", "needs-cache"]
 alloc-reuse = []
 tail-call = []
 # function/ opcode dispatch:
-# feature precedence: switch-dispatch (default) < jumptable-dispatch < fn-ptr-conversion-dispatch
-jumptable-dispatch = ["needs-jumptable"]
-fn-ptr-conversion-dispatch = ["needs-jumptable"]
+# feature precedence: jumptable-dispatch (default) < fn-ptr-conversion-dispatch
+fn-ptr-conversion-dispatch = []
 
 [dependencies]
 bnum = "0.12.0"

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -12,7 +12,6 @@ hash-cache = ["evmrs/hash-cache"]
 code-analysis-cache = ["evmrs/code-analysis-cache"]
 alloc-reuse = ["evmrs/alloc-reuse"]
 tail-call = ["evmrs/tail-call"]
-jumptable-dispatch = ["evmrs/jumptable-dispatch"]
 fn-ptr-conversion-dispatch = ["evmrs/fn-ptr-conversion-dispatch"]
 
 [dependencies]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,16 +15,6 @@ compile_error!(
     Either disable it or enable one or all of `code-analysis-cache` or `hash-cache`."
 );
 
-#[cfg(all(
-    feature = "needs-jumptable",
-    not(feature = "jumptable-dispatch"),
-    not(feature = "fn-ptr-conversion-dispatch"),
-))]
-compile_error!(
-    "Feature `needs-jumptable` is only a helper feature and not supposed to be enabled on its own.
-    Either disable it or enable one or all of `jumptable-dispatch` or `fn-ptr-conversion-dispatch`."
-);
-
 #[cfg(not(feature = "custom-evmc"))]
 pub extern crate evmc_vm_tosca as evmc_vm;
 #[cfg(feature = "custom-evmc")]

--- a/rust/src/utils/mod.rs
+++ b/rust/src/utils/mod.rs
@@ -1,9 +1,7 @@
 mod gas;
-#[cfg(any(feature = "needs-jumptable", feature = "code-analysis-cache"))]
 mod generic_static;
 mod helpers;
 
 pub use gas::*;
-#[cfg(any(feature = "needs-jumptable", feature = "code-analysis-cache"))]
 pub use generic_static::GetGenericStatic;
 pub use helpers::*;


### PR DESCRIPTION
This PR removes switch dispatch, makes jumptable dispatch the default and therefore also removes the feature `jumptable-dispatch`.
Because all dispatch technique now need the jumptable, the helper feature `needs-jumptable` is also removed.