### PR TITLE
evmrs: migrate to 2024 edition

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.83
+      uses: dtolnay/rust-toolchain@1.86
       with:
         components: rustfmt
     - name: load cache
@@ -49,7 +49,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.83
+      uses: dtolnay/rust-toolchain@1.86
       with:
         components: clippy
     - name: load cache
@@ -70,7 +70,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.83
+      uses: dtolnay/rust-toolchain@1.86
     - name: load cache
       uses: Swatinem/rust-cache@v2
       with:
@@ -91,7 +91,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.83
+      uses: dtolnay/rust-toolchain@1.86
     - name: load cache
       uses: Swatinem/rust-cache@v2
       with:
@@ -110,7 +110,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.83
+      uses: dtolnay/rust-toolchain@1.86
     - name: load cache
       uses: Swatinem/rust-cache@v2
       with:
@@ -228,7 +228,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.83
+      uses: dtolnay/rust-toolchain@1.86
     - name: load cache
       uses: Swatinem/rust-cache@v2
       with:

--- a/BUILD.md
+++ b/BUILD.md
@@ -14,7 +14,7 @@ git submodule update --init --recursive
 - C/C++ toolchain, Clang >= 16 and Gcc >= 11.4
     - Ubuntu/Debian package: `clang`
     - Recommended: install `clang-format`, `clangd`, and `gdb` for development
-- Rust toolchain >= 1.83.0
+- Rust toolchain >= 1.86.0
     - [install Rust](https://rustup.rs/)
     - Recommended: install `rust-analyzer` VSCode extension
 - [mockgen](https://github.com/golang/mock)

--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- install Rust toolchain >= 1.83.0 from [here](https://rustup.rs/)
+- install Rust toolchain >= 1.86.0 from [here](https://rustup.rs/)
 
 ## Building `evmrs` (shared C library)
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,7 +4,7 @@ members = ["driver", "benchmarks", "bencher", "llvm-profile-wrappers", "fuzz"]
 [package]
 name = "evmrs"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [profile.release]
 lto = true

--- a/rust/bencher/Cargo.toml
+++ b/rust/bencher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bencher"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 chrono = "0.4.38"

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "benchmarks"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 performance = ["evmrs/performance"]

--- a/rust/benchmarks/benches/interpreter.rs
+++ b/rust/benchmarks/benches/interpreter.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use benchmarks::RunArgs;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let (mut args, expected) = RunArgs::static_overhead(1);

--- a/rust/benchmarks/src/lib.rs
+++ b/rust/benchmarks/src/lib.rs
@@ -1,10 +1,11 @@
-use driver::{self, get_tx_context_zeroed, host_interface::null_ptr_host_interface, Instance};
+use driver::{self, Instance, get_tx_context_zeroed, host_interface::null_ptr_host_interface};
 use evmrs::{
+    MockExecutionMessage, Opcode,
     evmc_vm::{
-        ffi::{evmc_host_interface, evmc_message},
         Revision, StatusCode, Uint256,
+        ffi::{evmc_host_interface, evmc_message},
     },
-    u256, MockExecutionMessage, Opcode,
+    u256,
 };
 use sha3::{Digest, Keccak256};
 
@@ -215,7 +216,7 @@ impl RunArgs {
     pub fn memory(size: u32) -> (Self, u32) {
         fn memory_ref(input: u32) -> u32 {
             let mut values = vec![0; input as usize];
-            #[allow(clippy::needless_range_loop)]
+            #[allow(clippy::needless_range_loop, clippy::manual_slice_fill)]
             for i in 0..values.len() {
                 values[i] = i as u32;
             }

--- a/rust/driver/Cargo.toml
+++ b/rust/driver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "driver"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 mock = ["evmrs/mock"]

--- a/rust/driver/src/host_interface.rs
+++ b/rust/driver/src/host_interface.rs
@@ -5,11 +5,11 @@ mod mock_callbacks {
     use std::{ffi, slice};
 
     use evmrs::{
-        evmc_vm::{
-            ffi::{evmc_message, evmc_result, evmc_tx_context},
-            AccessStatus, Address, StorageStatus, Uint256,
-        },
         ExecutionContextTrait, MockExecutionContextTrait,
+        evmc_vm::{
+            AccessStatus, Address, StorageStatus, Uint256,
+            ffi::{evmc_message, evmc_result, evmc_tx_context},
+        },
     };
 
     pub extern "C" fn account_exists(context: *mut ffi::c_void, addr: *const Address) -> bool {

--- a/rust/driver/src/lib.rs
+++ b/rust/driver/src/lib.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use evmrs::evmc_vm::{
+    Address, ExecutionResult, Revision, StepResult, Uint256,
     ffi::{
         evmc_host_interface, evmc_message, evmc_step_status_code, evmc_tx_context,
         evmc_vm as evmc_vm_t, evmc_vm_steppable,
     },
-    Address, ExecutionResult, Revision, StepResult, Uint256,
 };
 
 pub mod host_interface;
@@ -101,7 +101,7 @@ impl Instance {
     ) -> ExecutionResult {
         let execute = self.execute.unwrap();
 
-        execute(self.0, host, context, revision, message, code, code_len).into()
+        unsafe { execute(self.0, host, context, revision, message, code, code_len).into() }
     }
 
     /// Run the interpreter (the `execute` function) with the supplied values. This is a safe
@@ -233,25 +233,27 @@ impl SteppableInstance {
     ) -> StepResult {
         let step_n = self.step_n.unwrap();
 
-        step_n(
-            self.0,
-            host,
-            context,
-            revision,
-            message,
-            code,
-            code_len,
-            status,
-            pc,
-            gas_refunds,
-            stack,
-            stack_len,
-            memory,
-            memory_len,
-            last_call_result_data,
-            last_call_result_data_len,
-            steps,
-        )
+        unsafe {
+            step_n(
+                self.0,
+                host,
+                context,
+                revision,
+                message,
+                code,
+                code_len,
+                status,
+                pc,
+                gas_refunds,
+                stack,
+                stack_len,
+                memory,
+                memory_len,
+                last_call_result_data,
+                last_call_result_data_len,
+                steps,
+            )
+        }
         .into()
     }
 

--- a/rust/fuzz/Cargo.toml
+++ b/rust/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/rust/fuzz/fuzz_targets/evmc_execute.rs
+++ b/rust/fuzz/fuzz_targets/evmc_execute.rs
@@ -4,14 +4,15 @@ use core::slice;
 use std::fmt::Debug;
 
 use arbitrary::Arbitrary;
-use driver::{host_interface::mocked_host_interface, Instance};
+use driver::{Instance, host_interface::mocked_host_interface};
 use evmrs::{
+    MockExecutionContextTrait,
     evmc_vm::{
-        ffi::{evmc_host_interface, evmc_message},
         AccessStatus, ExecutionResult, ExecutionTxContext, MessageKind, Revision, StatusCode,
         StorageStatus, Uint256,
+        ffi::{evmc_host_interface, evmc_message},
     },
-    u256, MockExecutionContextTrait,
+    u256,
 };
 use libfuzzer_sys::fuzz_target;
 

--- a/rust/llvm-profile-wrappers/Cargo.toml
+++ b/rust/llvm-profile-wrappers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llvm-profile-wrappers"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 

--- a/rust/src/evmc.rs
+++ b/rust/src/evmc.rs
@@ -1,9 +1,9 @@
 use std::process;
 
 use evmc_vm::{
-    ffi::evmc_capabilities, EvmcVm, ExecutionContext, ExecutionMessage, ExecutionResult, Revision,
+    EvmcVm, ExecutionContext, ExecutionMessage, ExecutionResult, Revision,
     StatusCode as EvmcStatusCode, StepResult, StepStatusCode as EvmcStepStatusCode,
-    SteppableEvmcVm, Uint256,
+    SteppableEvmcVm, Uint256, ffi::evmc_capabilities,
 };
 
 use crate::{

--- a/rust/src/ffi/evmc_vm.rs
+++ b/rust/src/ffi/evmc_vm.rs
@@ -1,15 +1,15 @@
 use std::{
-    ffi::{c_char, CStr},
+    ffi::{CStr, c_char},
     panic, slice,
 };
 
 use evmc_vm::{
-    ffi::{
-        evmc_capabilities, evmc_capabilities_flagset, evmc_host_context, evmc_host_interface,
-        evmc_message, evmc_result, evmc_revision, evmc_set_option_result, evmc_status_code,
-        evmc_vm as evmc_vm_t, EVMC_ABI_VERSION,
-    },
     EvmcContainer, EvmcVm, ExecutionContext, ExecutionMessage, ExecutionResult, SetOptionError,
+    ffi::{
+        EVMC_ABI_VERSION, evmc_capabilities, evmc_capabilities_flagset, evmc_host_context,
+        evmc_host_interface, evmc_message, evmc_result, evmc_revision, evmc_set_option_result,
+        evmc_status_code, evmc_vm as evmc_vm_t,
+    },
 };
 
 use crate::evmc::EvmRs;
@@ -68,7 +68,7 @@ extern "C" fn __evmc_set_option(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub(super) extern "C" fn evmc_create_evmrs() -> *mut evmc_vm_t {
     let new_instance = evmc_vm_t {
         abi_version: EVMC_ABI_VERSION as i32,
@@ -165,8 +165,8 @@ mod tests {
     use evmc_vm::ffi::{evmc_capabilities_flagset, evmc_set_option_result};
 
     use crate::ffi::{
-        evmc_vm::{__evmc_destroy, __evmc_get_capabilities, __evmc_set_option, evmc_create_evmrs},
         EVMC_CAPABILITY,
+        evmc_vm::{__evmc_destroy, __evmc_get_capabilities, __evmc_set_option, evmc_create_evmrs},
     };
 
     #[test]

--- a/rust/src/ffi/steppable_evmc_vm.rs
+++ b/rust/src/ffi/steppable_evmc_vm.rs
@@ -1,12 +1,12 @@
 use std::{ffi::c_void, panic, slice};
 
 use ::evmc_vm::{
+    ExecutionContext, ExecutionMessage, StatusCode, StepResult, StepStatusCode,
+    SteppableEvmcContainer, SteppableEvmcVm,
     ffi::{
         evmc_bytes32, evmc_capabilities, evmc_host_interface, evmc_message, evmc_revision,
         evmc_step_result, evmc_step_status_code, evmc_vm_steppable,
     },
-    ExecutionContext, ExecutionMessage, StatusCode, StepResult, StepStatusCode,
-    SteppableEvmcContainer, SteppableEvmcVm,
 };
 
 use crate::{
@@ -14,7 +14,7 @@ use crate::{
     ffi::evmc_vm::{self, EVMC_CAPABILITY},
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn evmc_create_steppable_evmrs() -> *mut evmc_vm_steppable {
     let new_instance = evmc_vm_steppable {
         vm: evmc_vm::evmc_create_evmrs(),

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -7,12 +7,12 @@ use evmc_vm::{
 
 use crate::{
     types::{
-        hash_cache, u256, CodeReader, ExecStatus, ExecutionContextTrait, ExecutionTxContext,
-        FailStatus, GetOpcodeError, Memory, Observer, Stack,
+        CodeReader, ExecStatus, ExecutionContextTrait, ExecutionTxContext, FailStatus,
+        GetOpcodeError, Memory, Observer, Stack, hash_cache, u256,
     },
     utils::{
-        check_min_revision, check_not_read_only, word_size, Gas, GasRefund, GetGenericStatic,
-        SliceExt,
+        Gas, GasRefund, GetGenericStatic, SliceExt, check_min_revision, check_not_read_only,
+        word_size,
     },
 };
 
@@ -1700,8 +1700,8 @@ mod tests {
     use crate::{
         interpreter::Interpreter,
         types::{
-            u256, Memory, MockExecutionContextTrait, MockExecutionMessage, NoOpObserver, Opcode,
-            Stack,
+            Memory, MockExecutionContextTrait, MockExecutionMessage, NoOpObserver, Opcode, Stack,
+            u256,
         },
     };
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -26,11 +26,11 @@ use llvm_profile_wrappers::{
 };
 #[cfg(feature = "mock")]
 pub use types::MockExecutionContextTrait;
-pub use types::{u256, ExecutionContextTrait, MockExecutionMessage, Opcode};
+pub use types::{ExecutionContextTrait, MockExecutionMessage, Opcode, u256};
 
 /// Dump coverage data when compiled with `RUSTFLAGS="-C instrument-coverage"`.
 /// Otherwise this is a no-op.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn evmrs_dump_coverage(filename: Option<&std::ffi::c_char>) {
     if llvm_profile_enabled() != 0 {
         llvm_profile_set_filename(filename);
@@ -39,7 +39,7 @@ pub extern "C" fn evmrs_dump_coverage(filename: Option<&std::ffi::c_char>) {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn evmrs_is_coverage_enabled() -> u8 {
     llvm_profile_enabled()
 }

--- a/rust/src/types/amount.rs
+++ b/rust/src/types/amount.rs
@@ -28,7 +28,7 @@ impl<'a> Arbitrary<'a> for u256 {
 
 impl LowerHex for u256 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let digits: [u64; 4] = transmute!(self.0 .0);
+        let digits: [u64; 4] = transmute!(self.0.0);
         if f.alternate() {
             write!(f, "0x")?;
         }
@@ -293,13 +293,13 @@ impl u256 {
     pub const MAX: Self = Self(U256::MAX);
 
     pub fn into_u64_with_overflow(self) -> (u64, bool) {
-        let digits: [u64; 4] = transmute!(self.0 .0);
+        let digits: [u64; 4] = transmute!(self.0.0);
         let overflow = digits[1..] != [0; 3];
         (digits[0], overflow)
     }
 
     pub fn into_u64_saturating(self) -> u64 {
-        let digits: [u64; 4] = transmute!(self.0 .0);
+        let digits: [u64; 4] = transmute!(self.0.0);
         if digits[1..] != [0; 3] {
             u64::MAX
         } else {
@@ -327,17 +327,16 @@ impl u256 {
         if m == u256::ZERO {
             return u256::ZERO;
         }
-        let s1 = bnum::types::U256::from_digits(transmute!(s1.0 .0));
+        let s1 = bnum::types::U256::from_digits(transmute!(s1.0.0));
         let s1 = U512::cast_from(s1);
-        let s2 = bnum::types::U256::from_digits(transmute!(s2.0 .0));
+        let s2 = bnum::types::U256::from_digits(transmute!(s2.0.0));
         let s2 = U512::cast_from(s2);
-        let m = bnum::types::U256::from_digits(transmute!(m.0 .0));
+        let m = bnum::types::U256::from_digits(transmute!(m.0.0));
         let m = U512::cast_from(m);
 
-        Self(U256(transmute!(*bnum::types::U256::cast_from(
-            (s1 + s2).rem(m)
-        )
-        .digits())))
+        Self(U256(transmute!(
+            *bnum::types::U256::cast_from((s1 + s2).rem(m)).digits()
+        )))
     }
 
     // ethnum has no support for addmod and mulmod yet (see https://github.com/nlordell/ethnum-rs/issues/10)
@@ -345,17 +344,16 @@ impl u256 {
         if m == u256::ZERO {
             return u256::ZERO;
         }
-        let s1 = bnum::types::U256::from_digits(transmute!(s1.0 .0));
+        let s1 = bnum::types::U256::from_digits(transmute!(s1.0.0));
         let s1 = U512::cast_from(s1);
-        let s2 = bnum::types::U256::from_digits(transmute!(s2.0 .0));
+        let s2 = bnum::types::U256::from_digits(transmute!(s2.0.0));
         let s2 = U512::cast_from(s2);
-        let m = bnum::types::U256::from_digits(transmute!(m.0 .0));
+        let m = bnum::types::U256::from_digits(transmute!(m.0.0));
         let m = U512::cast_from(m);
 
-        Self(U256(transmute!(*bnum::types::U256::cast_from(
-            (s1 * s2).rem(m)
-        )
-        .digits())))
+        Self(U256(transmute!(
+            *bnum::types::U256::cast_from((s1 * s2).rem(m)).digits()
+        )))
     }
 
     pub fn pow(self, exp: Self) -> Self {
@@ -449,7 +447,7 @@ impl u256 {
     }
 
     pub fn least_significant_byte(&self) -> u8 {
-        self.0 .0[0] as u8
+        self.0.0[0] as u8
     }
 
     pub fn to_le_bytes(self) -> [u8; 32] {
@@ -461,7 +459,7 @@ impl u256 {
 mod tests {
     use evmc_vm::Address;
 
-    use crate::types::amount::{u256, U64Overflow};
+    use crate::types::amount::{U64Overflow, u256};
 
     #[test]
     fn display() {

--- a/rust/src/types/code_analysis.rs
+++ b/rust/src/types/code_analysis.rs
@@ -8,7 +8,7 @@ use nohash_hasher::BuildNoHashHasher;
 
 #[cfg(feature = "code-analysis-cache")]
 use crate::types::Cache;
-use crate::types::{code_byte_type, u256, CodeByteType};
+use crate::types::{CodeByteType, code_byte_type, u256};
 #[cfg(feature = "fn-ptr-conversion-dispatch")]
 use crate::types::{OpFnData, PcMap};
 #[cfg(feature = "code-analysis-cache")]
@@ -168,9 +168,9 @@ impl<const STEPPABLE: bool> CodeAnalysis<STEPPABLE> {
 mod tests {
     #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     use crate::types::CodeByteType;
-    #[cfg(feature = "fn-ptr-conversion-dispatch")]
-    use crate::types::{u256, OpFnData};
     use crate::types::{CodeAnalysis, Opcode};
+    #[cfg(feature = "fn-ptr-conversion-dispatch")]
+    use crate::types::{OpFnData, u256};
 
     #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
     #[test]

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -4,7 +4,7 @@ use std::{self, ops::Deref};
 
 #[cfg(feature = "fn-ptr-conversion-dispatch")]
 use crate::interpreter::OpFn;
-use crate::types::{u256, AnalysisContainer, CodeAnalysis, CodeByteType, FailStatus};
+use crate::types::{AnalysisContainer, CodeAnalysis, CodeByteType, FailStatus, u256};
 
 #[cfg(not(feature = "fn-ptr-conversion-dispatch"))]
 struct PushDataLen<const N: usize>;
@@ -142,8 +142,9 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
 #[cfg(test)]
 mod tests {
     use crate::types::{
+        FailStatus, Opcode,
         code_reader::{CodeReader, GetOpcodeError},
-        u256, FailStatus, Opcode,
+        u256,
     };
 
     #[test]

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -3,8 +3,8 @@ use std::sync::Mutex;
 use std::{cmp::max, iter};
 
 use crate::{
-    types::{u256, FailStatus},
-    utils::{word_size, Gas},
+    types::{FailStatus, u256},
+    utils::{Gas, word_size},
 };
 
 #[cfg(feature = "alloc-reuse")]
@@ -47,7 +47,7 @@ impl Memory {
         fn expand_raw(m: &mut Memory, new_len: u64, gas_left: &mut Gas) -> Result<(), FailStatus> {
             let current_len = m.0.len() as u64;
             m.consume_expansion_cost(new_len, gas_left)?;
-            m.0.extend(iter::repeat(0).take((new_len - current_len) as usize));
+            m.0.extend(iter::repeat_n(0, (new_len - current_len) as usize));
             Ok(())
         }
 
@@ -159,7 +159,7 @@ impl Memory {
 #[cfg(test)]
 mod tests {
     use crate::{
-        types::{memory::Memory, u256, FailStatus},
+        types::{FailStatus, memory::Memory, u256},
         utils::Gas,
     };
 

--- a/rust/src/types/mock_execution_message.rs
+++ b/rust/src/types/mock_execution_message.rs
@@ -1,6 +1,6 @@
 use std::ptr;
 
-use evmc_vm::{ffi::evmc_message, Address, ExecutionMessage, MessageKind, Uint256};
+use evmc_vm::{Address, ExecutionMessage, MessageKind, Uint256, ffi::evmc_message};
 
 use crate::types::u256;
 

--- a/rust/src/types/observer.rs
+++ b/rust/src/types/observer.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, io::Write};
 
-use crate::interpreter::Interpreter;
 #[cfg(feature = "fn-ptr-conversion-dispatch")]
 use crate::Opcode;
+use crate::interpreter::Interpreter;
 
 pub trait Observer<const STEPPABLE: bool> {
     fn pre_op(&mut self, interpreter: &Interpreter<STEPPABLE>);

--- a/rust/src/types/op_fn_data.rs
+++ b/rust/src/types/op_fn_data.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 
 use crate::{
+    Opcode,
     interpreter::{GenericJumptable, OpFn},
     types::CodeByteType,
     u256,
     utils::GetGenericStatic,
-    Opcode,
 };
 
 #[derive(Clone, PartialEq, Eq)]
@@ -39,10 +39,16 @@ impl<const STEPPABLE: bool> OpFnData<STEPPABLE> {
     pub fn code_byte_type(&self) -> CodeByteType {
         match self.func {
             None => CodeByteType::DataOrInvalid,
-            Some(func) if func == GenericJumptable::get()[Opcode::JumpDest as u8 as usize] => {
-                CodeByteType::JumpDest
+            Some(func) => {
+                if std::ptr::fn_addr_eq(
+                    func,
+                    GenericJumptable::get::<STEPPABLE>()[Opcode::JumpDest as u8 as usize],
+                ) {
+                    CodeByteType::JumpDest
+                } else {
+                    CodeByteType::Opcode
+                }
             }
-            Some(_) => CodeByteType::Opcode,
         }
     }
 

--- a/rust/src/types/stack.rs
+++ b/rust/src/types/stack.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 #[cfg(feature = "alloc-reuse")]
 use std::sync::Mutex;
 
-use crate::types::{u256, FailStatus};
+use crate::types::{FailStatus, u256};
 
 struct NonZero<const N: usize>;
 
@@ -184,7 +184,7 @@ impl Stack {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{stack::Stack, u256, FailStatus};
+    use crate::types::{FailStatus, stack::Stack, u256};
 
     #[test]
     fn internals() {

--- a/rust/src/types/tx_context.rs
+++ b/rust/src/types/tx_context.rs
@@ -6,8 +6,8 @@
 use std::slice;
 
 use evmc_vm::{
-    ffi::{evmc_tx_context, evmc_tx_initcode},
     Address, Uint256,
+    ffi::{evmc_tx_context, evmc_tx_initcode},
 };
 
 /// EVMC transaction context.

--- a/rust/src/utils/gas.rs
+++ b/rust/src/utils/gas.rs
@@ -1,7 +1,7 @@
 use evmc_vm::{AccessStatus, Address, Revision};
 
 use crate::{
-    types::{u256, ExecutionContextTrait, FailStatus},
+    types::{ExecutionContextTrait, FailStatus, u256},
     utils::word_size,
 };
 
@@ -41,11 +41,7 @@ impl PartialOrd<u64> for Gas {
 
 impl Gas {
     pub fn new(gas: i64) -> Self {
-        if gas < 0 {
-            Self(0)
-        } else {
-            Self(gas as u64)
-        }
+        if gas < 0 { Self(0) } else { Self(gas as u64) }
     }
 
     pub fn as_u64(&self) -> u64 {
@@ -145,7 +141,7 @@ mod tests {
 
     use crate::{
         interpreter::Interpreter,
-        types::{u256, FailStatus, MockExecutionContextTrait, MockExecutionMessage, Opcode},
+        types::{FailStatus, MockExecutionContextTrait, MockExecutionMessage, Opcode, u256},
         utils::Gas,
     };
 

--- a/rust/src/utils/helpers.rs
+++ b/rust/src/utils/helpers.rs
@@ -3,7 +3,7 @@ use std::cmp::min;
 use evmc_vm::{ExecutionMessage, MessageFlags, Revision};
 
 use crate::{
-    types::{u256, FailStatus},
+    types::{FailStatus, u256},
     utils::Gas,
 };
 
@@ -73,7 +73,7 @@ mod tests {
 
     use crate::{
         interpreter::Interpreter,
-        types::{u256, FailStatus, MockExecutionContextTrait, MockExecutionMessage},
+        types::{FailStatus, MockExecutionContextTrait, MockExecutionMessage, u256},
         utils::{self, Gas, SliceExt},
     };
 

--- a/rust/tests/ffi.rs
+++ b/rust/tests/ffi.rs
@@ -2,13 +2,12 @@
 #[cfg(not(feature = "custom-evmc"))]
 use driver::TX_CONTEXT_ZEROED;
 use driver::{
-    get_tx_context_zeroed,
+    Instance, SteppableInstance, ZERO, get_tx_context_zeroed,
     host_interface::{self, null_ptr_host_interface},
-    Instance, SteppableInstance, ZERO,
 };
 use evmrs::{
-    evmc_vm::{Revision, StatusCode, StepStatusCode},
     MockExecutionContextTrait, MockExecutionMessage, Opcode,
+    evmc_vm::{Revision, StatusCode, StepStatusCode},
 };
 
 #[test]


### PR DESCRIPTION
This PR migrates all Rust crates to the [2024 Rust edition](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html#rust-2024).
Editions are Rust's method of introducing backwards incompatible changes without splitting the ecosystem.
Each crate can individually opt in to newer editions, but can still use other creates which use older editions.

The changes are mostly due to different code formatting rules. Besides that, it is now necessary to use unsafe blocks in functions even if the function itself is already unsafe. Also, the `no_mangle` attribute is now unsafe.