### PR TITLE
evmrs: put unsafe hint in Memory::get_word behind feature unsafe-hints

### DIFF
--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -111,10 +111,15 @@ impl Memory {
 
     pub fn get_word(&mut self, offset: u256, gas_left: &mut Gas) -> Result<u256, FailStatus> {
         let slice = self.get_mut_slice(offset, 32, gas_left)?;
+        let mut arr = [0; 32];
+        #[cfg(feature = "unsafe-hints")]
         // SAFETY:
         // The slice is 32 bytes long.
-        let slice = unsafe { &*(slice.as_ptr() as *const [u8; 32]) };
-        Ok(u256::from_be_bytes(*slice))
+        unsafe {
+            std::hint::assert_unchecked(slice.len() == 32);
+        }
+        arr.copy_from_slice(slice);
+        Ok(u256::from_be_bytes(arr))
     }
 
     pub fn get_mut_byte(


### PR DESCRIPTION
Currently, Memory:.get_word uses unsafe code to avoid the range check, because it is known that the slice is always 32 bytes long.
This PR rewrites get_word such that by default no unsafe code is used, but when feature unsafe-hints is enabled compiler hints are added to remove the range check again.