### PR TITLE
evmrs: set call depth input range for fuzzer to 0..=1024

### DIFF
--- a/rust/fuzz/fuzz_targets/evmc_execute.rs
+++ b/rust/fuzz/fuzz_targets/evmc_execute.rs
@@ -50,7 +50,7 @@ impl<'a> Arbitrary<'a> for InterpreterArgs<'a> {
                 MessageKind::EVMC_EOFCREATE,
             ])?,
             flags: u32::arbitrary(u)?,
-            depth: i32::arbitrary(u)?,
+            depth: u.int_in_range(0..=1024)?,
             gas: u.int_in_range(0..=100_000_000)?, // see go/ct/evm_fuzz_test.go
             recipient: u256::arbitrary(u)?.into(),
             sender: u256::arbitrary(u)?.into(),


### PR DESCRIPTION
#63 failed because the call depth overflowed. This only happend because until now the call depth was not restricted to valid values. This PR changes that and makes sure that the input call depth is always in the range 0..=1024.