### PR TITLE
evmrs: constrain lifetimes of references created from pointers

### DIFF
--- a/rust/src/ffi/evmc_vm.rs
+++ b/rust/src/ffi/evmc_vm.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::{CStr, c_char},
-    panic, slice,
+    panic,
 };
 
 use evmc_vm::{
@@ -12,7 +12,12 @@ use evmc_vm::{
     },
 };
 
-use crate::evmc::EvmRs;
+use crate::{
+    evmc::EvmRs,
+    ffi::{
+        LifetimeToken, ref_from_ptr_scoped, ref_mut_from_ptr_scoped, slice_from_raw_parts_scoped,
+    },
+};
 
 static EVM_RS_NAME: &CStr = c"evmrs";
 static EVM_RS_VERSION: &CStr = c"0.1.0";
@@ -30,6 +35,8 @@ extern "C" fn __evmc_set_option(
     key: *const c_char,
     value: *const c_char,
 ) -> evmc_set_option_result {
+    let token = LifetimeToken;
+
     assert!(!instance.is_null());
 
     if key.is_null() {
@@ -59,7 +66,8 @@ extern "C" fn __evmc_set_option(
     // `instance` is not null. The caller must make sure that `instance` points to a valid
     // `EvmcContainer::<EvmRs>` (which is the case it it was created with evmc_create_evmrs) and the
     // pointer is unique.
-    let container = unsafe { &mut **(instance as *mut EvmcContainer<EvmRs>) };
+    let container =
+        unsafe { ref_mut_from_ptr_scoped(instance as *mut EvmcContainer<EvmRs>, &token) };
 
     match container.set_option(key, value) {
         Ok(()) => evmc_set_option_result::EVMC_SET_OPTION_SUCCESS,
@@ -110,6 +118,8 @@ extern "C" fn __evmc_execute(
     code: *const u8,
     code_size: usize,
 ) -> evmc_result {
+    let token = LifetimeToken;
+
     if instance.is_null()
         || (host.is_null() && EVMC_CAPABILITY != evmc_capabilities::EVMC_CAPABILITY_PRECOMPILES)
         || message.is_null()
@@ -121,7 +131,7 @@ extern "C" fn __evmc_execute(
 
     // SAFETY:
     // `message`` is not null. The caller must make sure it points to a valid `ExecutionMessage`.
-    let execution_message = ExecutionMessage::from(unsafe { &*message });
+    let execution_message = ExecutionMessage::from(unsafe { ref_from_ptr_scoped(message, &token) });
 
     let code_ref = if code.is_null() {
         &[]
@@ -129,14 +139,15 @@ extern "C" fn __evmc_execute(
         // SAFETY:
         // `code` is not null and `code_size > 0`. The caller must make sure that the size is
         // valid.
-        unsafe { slice::from_raw_parts(code, code_size) }
+        unsafe { slice_from_raw_parts_scoped(code, code_size, &token) }
     };
 
     // SAFETY:
     // `instance` is not null. The caller must make sure that `instance` points to a valid
     // `EvmcContainer::<EvmRs>` (which is the case it it was created with evmc_create_evmrs) and the
     // pointer is unique.
-    let container = unsafe { &mut **(instance as *mut EvmcContainer<EvmRs>) };
+    let container =
+        unsafe { ref_mut_from_ptr_scoped(instance as *mut EvmcContainer<EvmRs>, &token) };
 
     panic::catch_unwind(|| {
         let mut execution_context = if host.is_null() {
@@ -145,8 +156,8 @@ extern "C" fn __evmc_execute(
             // SAFETY:
             // `host` is not null. The caller must make sure that it points to a valid
             // `evmc_host_interface`.
-            let execution_context = ExecutionContext::new(unsafe { &*host }, context);
-            Some(execution_context)
+            let host = unsafe { ref_from_ptr_scoped(host, &token) };
+            Some(ExecutionContext::new(host, context))
         };
 
         container.execute(

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -1,3 +1,43 @@
 mod evmc_vm;
 mod steppable_evmc_vm;
+use std::slice;
+
 pub use evmc_vm::EVMC_CAPABILITY;
+
+/// This type is indented to be used to enforce the correct lifetime for references created from
+/// pointers obtained via FFI. It is assumed that the lifetime of the pointer is bound by the
+/// lifetime of the token.
+struct LifetimeToken;
+
+/// # Safety
+/// ptr must be non-null and valid for reads for the lifetime of the borrow of token.
+#[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
+unsafe fn ref_from_ptr_scoped<'s, T>(ptr: *const T, _token: &'s LifetimeToken) -> &'s T {
+    // SAFETY:
+    // ptr is non-null and valid for reads for the lifetime of the borrow of token
+    unsafe { &*ptr }
+}
+
+/// # Safety
+/// ptr must be non-null and valid for reads and writes for the lifetime of the borrow of token.
+#[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
+#[allow(clippy::mut_from_ref)] // false positive
+unsafe fn ref_mut_from_ptr_scoped<'s, T>(ptr: *mut T, _token: &'s LifetimeToken) -> &'s mut T {
+    // SAFETY:
+    // ptr is non-null and valid for reads and writes for the lifetime of the borrow of token
+    unsafe { &mut *ptr }
+}
+
+/// # Safety
+/// ptr must be non-null and valid for reads for `len * mem::size_of::<T>()` many bytes for the
+/// lifetime of the borrow of token.
+#[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
+unsafe fn slice_from_raw_parts_scoped<'s, T>(
+    ptr: *const T,
+    len: usize,
+    _token: &'s LifetimeToken,
+) -> &'s [T] {
+    // SAFETY:
+    // ptr is non-null and valid for reads for the lifetime of the borrow of token
+    unsafe { slice::from_raw_parts(ptr, len) }
+}

--- a/rust/src/ffi/steppable_evmc_vm.rs
+++ b/rust/src/ffi/steppable_evmc_vm.rs
@@ -11,7 +11,11 @@ use ::evmc_vm::{
 
 use crate::{
     evmc::EvmRs,
-    ffi::evmc_vm::{self, EVMC_CAPABILITY},
+    ffi::{
+        LifetimeToken,
+        evmc_vm::{self, EVMC_CAPABILITY},
+        ref_from_ptr_scoped, ref_mut_from_ptr_scoped, slice_from_raw_parts_scoped,
+    },
 };
 
 #[unsafe(no_mangle)]
@@ -61,6 +65,8 @@ extern "C" fn __evmc_step_n(
     last_call_result_data_size: usize,
     steps: i32,
 ) -> evmc_step_result {
+    let token = LifetimeToken;
+
     if instance.is_null()
         || (host.is_null() && EVMC_CAPABILITY != evmc_capabilities::EVMC_CAPABILITY_PRECOMPILES)
         || message.is_null()
@@ -76,7 +82,7 @@ extern "C" fn __evmc_step_n(
     // SAFETY:
     // `message` is not null. The caller must make sure that is points to a valid
     // `ExecutionMessage`.
-    let execution_message = ExecutionMessage::from(unsafe { &*message });
+    let execution_message = ExecutionMessage::from(unsafe { ref_from_ptr_scoped(message, &token) });
 
     let code_ref = if code.is_null() {
         &[]
@@ -84,14 +90,15 @@ extern "C" fn __evmc_step_n(
         // SAFETY:
         // `code` is not null and `code_size > 0`. The caller must make sure that the size is
         // valid.
-        unsafe { slice::from_raw_parts(code, code_size) }
+        unsafe { slice_from_raw_parts_scoped(code, code_size, &token) }
     };
 
     // SAFETY:
     // `instance` is not null. The caller must make sure that it points to a valid
     // `SteppableEvmcContainer::<EvmRs>` (which is the case it it was created with
     // evmc_create_steppable_evmrs) an the pointer is unique.
-    let container = unsafe { &mut **(instance as *mut SteppableEvmcContainer<EvmRs>) };
+    let container =
+        unsafe { ref_mut_from_ptr_scoped(instance as *mut SteppableEvmcContainer<EvmRs>, &token) };
 
     panic::catch_unwind(|| {
         let mut execution_context = if host.is_null() {
@@ -100,8 +107,8 @@ extern "C" fn __evmc_step_n(
             // SAFETY:
             // `host` is not null. The caller must make sure that it points to a valid
             // `evmc_host_interface`.
-            let execution_context = ExecutionContext::new(unsafe { &*host }, context);
-            Some(execution_context)
+            let host = unsafe { ref_from_ptr_scoped(host, &token) };
+            Some(ExecutionContext::new(host, context))
         };
 
         let stack = if stack.is_null() {


### PR DESCRIPTION
When creating references from pointers obtained via FFI, the lifetime is not constrained in any way when using `unsafe { &*ptr }` or [`slice_from_raw_parts`](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html).
This PR constraints the lifetime of those references by the lifetime of a token which is created at the beginning of the functions which get called via FFI.
This way, the references live only as long as the reference of the token - so only until the end of the scope, which is exactly what is expected of them.