### PR TITLE
evmrs(evmc-vm): add steppable evmc interface and add code_hash field to ExecutionMessage

### DIFF
--- a/rust/evmc-vm/src/types.rs
+++ b/rust/evmc-vm/src/types.rs
@@ -18,6 +18,9 @@ pub type MessageFlags = ffi::evmc_flags;
 /// EVMC status code.
 pub type StatusCode = ffi::evmc_status_code;
 
+/// EVMC step status code.
+pub type StepStatusCode = ffi::evmc_step_status_code;
+
 /// EVMC access status.
 pub type AccessStatus = ffi::evmc_access_status;
 


### PR DESCRIPTION
This PR makes evmc-vm compatible with tosca by adding the steppable interface and code_hash field.
This is just a squashed version of:
- https://github.com/fantom-foundation/evmc/pull/3
- https://github.com/fantom-foundation/evmc/pull/4