### PR TITLE
evmrs(evmc-vm): fix UB

### DIFF
--- a/rust/evmc-vm/src/container.rs
+++ b/rust/evmc-vm/src/container.rs
@@ -7,6 +7,7 @@ use crate::EvmcVm;
 use std::ops::{Deref, DerefMut};
 
 /// Container struct for EVMC instances and user-defined data.
+#[repr(C)]
 pub struct EvmcContainer<T>
 where
     T: EvmcVm + Sized,
@@ -67,6 +68,7 @@ where
 }
 
 /// Container struct for steppable EVMC instances and user-defined data.
+#[repr(C)]
 pub struct SteppableEvmcContainer<T>
 where
     T: EvmcVm + Sized,


### PR DESCRIPTION
This PR fixes undefined behavior in evmc-vm.
In particular it avoids allocations of size 0 and uses `repr(C)` for the container types so that is ensured that the first field is at offset 0.

This PR contains parts of:
- https://github.com/Fantom-foundation/evmc/pull/5
- https://github.com/Fantom-foundation/evmc/pull/6