### PR TITLE
lfvm: Check whether code size exceeds maximum

### DIFF
--- a/go/interpreter/lfvm/errors.go
+++ b/go/interpreter/lfvm/errors.go
@@ -24,4 +24,5 @@ const (
 	errMaxMemoryExpansionSize = tosca.ConstError("max memory expansion size exceeded")
 	errStackUnderflow         = tosca.ConstError("stack underflow")
 	errStackOverflow          = tosca.ConstError("stack overflow")
+	errCodeSizeExceeded       = tosca.ConstError("max code size exceeded")
 )

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -18,6 +18,11 @@ import (
 	"github.com/holiman/uint256"
 )
 
+const (
+	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
+	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
+)
+
 func opStop() status {
 	return statusStopped
 }
@@ -849,11 +854,7 @@ func genericCreate(c *context, kind tosca.CallKind) error {
 // Returns the gas cost for the size of the init code and nil, or
 // zero and an error if size is greater than MaxInitCodeSize.
 func computeCodeSizeCost(size uint64) (tosca.Gas, error) {
-	const (
-		maxCodeSize     = 24576           // Maximum bytecode to permit for a contract
-		maxInitCodeSize = 2 * maxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
-	)
-	if size > maxInitCodeSize {
+	if size > MaxInitCodeSize {
 		return 0, errInitCodeTooLarge
 	}
 	// Once per word of the init code when creating a contract.

--- a/go/interpreter/lfvm/lfvm.go
+++ b/go/interpreter/lfvm/lfvm.go
@@ -124,6 +124,10 @@ func (v *lfvm) Run(params tosca.Parameters) (tosca.Result, error) {
 		return tosca.Result{}, &tosca.ErrUnsupportedRevision{Revision: params.Revision}
 	}
 
+	if len(params.Code) > MaxInitCodeSize {
+		return tosca.Result{}, errCodeSizeExceeded
+	}
+
 	converted := v.converter.Convert(
 		params.Code,
 		params.CodeHash,

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -11,6 +11,7 @@
 package lfvm
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -69,5 +70,41 @@ func TestLfvm_newVm_returnsErrorWithWrongConfiguration(t *testing.T) {
 	_, err := newVm(config)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestLfvm_CodeLargerThanMaxInitCodeSizeReturnsAnError(t *testing.T) {
+	tests := map[string]struct {
+		codeSize int
+		err      error
+	}{
+		"small code": {
+			codeSize: MaxInitCodeSize - 1,
+			err:      nil,
+		},
+		"exact code": {
+			codeSize: MaxInitCodeSize,
+			err:      nil,
+		},
+		"large code": {
+			codeSize: MaxInitCodeSize + 1,
+			err:      errCodeSizeExceeded,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := config{
+				ConversionConfig: ConversionConfig{},
+			}
+			vm, err := newVm(config)
+			if err != nil {
+				t.Fatalf("unexpected error")
+			}
+			_, err = vm.Run(tosca.Parameters{Code: make([]byte, test.codeSize)})
+			if !errors.Is(err, test.err) {
+				t.Fatalf("unexpected error: want %v, got %v", test.err, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The lfvm uses an uint16 PC and can therefore not work with codes greater than max uint16. The maximum size of codes that can be executed on chain are init codes which are limited to 49152 bytes by ethereum.  
An error is now returned if the code size exceeds 49152 opcodes/bytes.