### PR TITLE
evmrs: fuzz with release profile and performance feature

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -237,7 +237,7 @@ jobs:
       run: cargo install cargo-fuzz
     - name: cargo fuzz evmc execute
       working-directory: rust
-      run: cargo fuzz run --sanitizer none evmc_execute -- -max_total_time=10
+      run: cargo fuzz run --release --sanitizer none evmc_execute -- -max_total_time=10  -- -rss_limit_mb=6000
 
   deps:
     name: unused deps

--- a/rust/fuzz/Cargo.toml
+++ b/rust/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1.4.1" }
-evmrs = { path = "..", features = ["mock", "fuzzing"] }
+evmrs = { path = "..", features = ["mock", "fuzzing", "performance"] }
 driver = { path = "../driver", features = ["mock"] }
 
 [[bin]]


### PR DESCRIPTION
Currently, fuzzing can fail because of overflows because the fuzz runner by default compiles the code with additional overflow checks. However, in some cases operations are expected to wrap around. This PR uses the default release profile instead, and also enables the performance feature of evmrs when fuzzing.