### PR TITLE
evmrs: use empty containers instead of optional ones

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
-members = ["driver", "benchmarks", "bencher", "llvm-profile-wrappers", "fuzz"]
+members = [
+    "driver",
+    "benchmarks",
+    "bencher",
+    "llvm-profile-wrappers",
+    "fuzz",
+    "evmc-vm",
+]
 
 [package]
 name = "evmrs"

--- a/rust/benchmarks/src/lib.rs
+++ b/rust/benchmarks/src/lib.rs
@@ -418,7 +418,7 @@ impl RunArgs {
         hasher.finalize_into((&mut code_hash).into());
 
         let message = MockExecutionMessage {
-            input: Some(Box::leak(Box::from(input.as_slice()))),
+            input: Box::leak(Box::from(input.as_slice())),
             code_hash: Some(Box::leak(Box::new(u256::from_le_bytes(code_hash).into()))),
             ..Default::default()
         };
@@ -460,7 +460,6 @@ pub fn run(args: &mut RunArgs) -> u32 {
         args.instance
             .run_with_null_context(&args.host, args.revision, &args.message, args.code);
     assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
-    let output = result.output.unwrap();
-    assert_eq!(output.len(), 32);
-    u32::from_be_bytes(output[28..32].try_into().unwrap())
+    assert_eq!(result.output.len(), 32);
+    u32::from_be_bytes(result.output[28..32].try_into().unwrap())
 }

--- a/rust/evmc-vm/src/container.rs
+++ b/rust/evmc-vm/src/container.rs
@@ -163,7 +163,7 @@ mod tests {
                 status_code: StatusCode::EVMC_FAILURE,
                 gas_left: 0,
                 gas_refund: 0,
-                output: None,
+                output: Box::default(),
                 create_address: None,
             }
         }

--- a/rust/src/evmc.rs
+++ b/rust/src/evmc.rs
@@ -85,14 +85,10 @@ impl SteppableEvmcVm for EvmRs {
                 pc,
                 gas_left: gas_refund,
                 gas_refund,
-                output: None,
+                output: Box::default(),
                 stack: stack.to_owned(),
                 memory: memory.to_owned(),
-                last_call_return_data: if last_call_return_data.is_empty() {
-                    None
-                } else {
-                    Some(Box::from(last_call_return_data))
-                },
+                last_call_return_data: Box::from(last_call_return_data),
             };
         }
         assert_ne!(
@@ -115,7 +111,7 @@ impl SteppableEvmcVm for EvmRs {
             gas_refund,
             stack,
             memory,
-            Some(Box::from(last_call_return_data)),
+            Box::from(last_call_return_data),
             Some(steps),
         );
         match self.observer_type {

--- a/rust/src/ffi/evmc_vm.rs
+++ b/rust/src/ffi/evmc_vm.rs
@@ -157,7 +157,7 @@ extern "C" fn __evmc_execute(
         status_code: evmc_status_code::EVMC_INTERNAL_ERROR,
         gas_left: 0,
         gas_refund: 0,
-        output: None,
+        output: Box::default(),
         create_address: None,
     })
     .into()

--- a/rust/src/ffi/steppable_evmc_vm.rs
+++ b/rust/src/ffi/steppable_evmc_vm.rs
@@ -149,10 +149,10 @@ extern "C" fn __evmc_step_n(
         pc: 0,
         gas_left: 0,
         gas_refund: 0,
-        output: None,
+        output: Box::default(),
         stack: Vec::new(),
         memory: Vec::new(),
-        last_call_return_data: None,
+        last_call_return_data: Box::default(),
     })
     .into()
 }

--- a/rust/src/types/mock_execution_message.rs
+++ b/rust/src/types/mock_execution_message.rs
@@ -13,11 +13,11 @@ pub struct MockExecutionMessage {
     pub gas: i64,
     pub recipient: Address,
     pub sender: Address,
-    pub input: Option<&'static [u8]>,
+    pub input: &'static [u8],
     pub value: Uint256,
     pub create2_salt: Uint256,
     pub code_address: Address,
-    pub code: Option<&'static [u8]>,
+    pub code: &'static [u8],
     pub code_hash: Option<&'static Uint256>,
 }
 
@@ -32,13 +32,21 @@ impl MockExecutionMessage {
             gas: self.gas,
             recipient: self.recipient,
             sender: self.sender,
-            input_data: self.input.map(<[u8]>::as_ptr).unwrap_or(ptr::null()),
-            input_size: self.input.map(<[u8]>::len).unwrap_or_default(),
+            input_data: if self.input.is_empty() {
+                ptr::null()
+            } else {
+                self.input.as_ptr()
+            },
+            input_size: self.input.len(),
             value: self.value,
             create2_salt: self.create2_salt,
             code_address: self.code_address,
-            code: self.code.map(<[u8]>::as_ptr).unwrap_or(ptr::null()),
-            code_size: self.code.map(<[u8]>::len).unwrap_or_default(),
+            code: if self.code.is_empty() {
+                ptr::null()
+            } else {
+                self.code.as_ptr()
+            },
+            code_size: self.code.len(),
             code_hash: self.code_hash.map(|h| h as *const _).unwrap_or(ptr::null()),
         }
     }
@@ -53,11 +61,11 @@ impl Default for MockExecutionMessage {
             gas: Self::DEFAULT_INIT_GAS as i64,
             recipient: u256::ZERO.into(),
             sender: u256::ZERO.into(),
-            input: None,
+            input: &[],
             value: u256::ZERO.into(),
             create2_salt: u256::ZERO.into(),
             code_address: u256::ZERO.into(),
-            code: None,
+            code: &[],
             code_hash: None,
         }
     }

--- a/rust/src/types/status_code.rs
+++ b/rust/src/types/status_code.rs
@@ -97,10 +97,10 @@ impl From<FailStatus> for StepResult {
             pc: 0,
             gas_left: 0,
             gas_refund: 0,
-            output: None,
+            output: Box::default(),
             stack: Vec::new(),
             memory: Vec::new(),
-            last_call_return_data: None,
+            last_call_return_data: Box::default(),
         }
     }
 }
@@ -111,7 +111,7 @@ impl From<FailStatus> for ExecutionResult {
             status_code: fail_status.into(),
             gas_left: 0,
             gas_refund: 0,
-            output: None,
+            output: Box::default(),
             create_address: None,
         }
     }


### PR DESCRIPTION
This PR changes the type for the fields `input`, `code`, `output` and `last_call_return_data` from optional slices or optional boxed slices to slices or boxes slices.
Semantically, there is no difference between having no input or empty input (the same also holds for the other fields).
By making the fields non-optional, it is now sufficient to check if they are empty instead of checking if they are None or empty. This also removes branching overall.