### PR TITLE
Geth adapter: Refactor isPrecompiledContract function

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -272,13 +272,17 @@ func (a *runContextAdapter) Call(kind tosca.CallKind, parameter tosca.CallParame
 		defer func() { debugCallEnd(result, reserr) }()
 	}
 
-	gas := encodeReadOnlyInGas(uint64(parameter.Gas), parameter.CodeAddress, a.readOnly)
+	rules := a.evm.ChainConfig().Rules(a.evm.Context.BlockNumber, a.evm.Context.Random != nil, a.evm.Context.Time)
+	revision, err := convertRevision(rules)
+	if err != nil {
+		return tosca.CallResult{}, fmt.Errorf("unsupported revision: %w", err)
+	}
+	gas := encodeReadOnlyInGas(uint64(parameter.Gas), parameter.CodeAddress, revision, a.readOnly)
 
 	// Documentation of the parameters can be found here: t.ly/yhxC
 	toAddr := common.Address(parameter.Recipient)
 
 	var (
-		err            error
 		output         []byte
 		returnGas      uint64
 		createdAddress tosca.Address
@@ -334,8 +338,8 @@ func (a *runContextAdapter) Call(kind tosca.CallKind, parameter tosca.CallParame
 // on a new interpreter per transaction call (for proper) scoping
 // which is not a desired trait for Tosca interpreter implementations.
 // With this trick, this requirement is circumvented.
-func encodeReadOnlyInGas(gas uint64, recipient tosca.Address, readOnly bool) uint64 {
-	if !isPrecompiledContract(recipient) {
+func encodeReadOnlyInGas(gas uint64, recipient tosca.Address, revision tosca.Revision, readOnly bool) uint64 {
+	if !isPrecompiledContract(recipient, revision) {
 		if readOnly {
 			gas += (1 << 63)
 		}
@@ -621,12 +625,19 @@ func bigIntToWord(value *big.Int) (tosca.Word, error) {
 	return tosca.Word(res), err
 }
 
-func isPrecompiledContract(recipient tosca.Address) bool {
-	// the addresses 1-9 are precompiled contracts
-	for i := 0; i < 18; i++ {
-		if recipient[i] != 0 {
-			return false
-		}
+func isPrecompiledContract(recipient tosca.Address, revision tosca.Revision) bool {
+	var precompiles map[common.Address]geth.PrecompiledContract
+	switch revision {
+	case tosca.R14_Prague:
+		precompiles = geth.PrecompiledContractsPrague
+	case tosca.R13_Cancun:
+		precompiles = geth.PrecompiledContractsCancun
+	case tosca.R12_Shanghai, tosca.R11_Paris, tosca.R10_London, tosca.R09_Berlin:
+		precompiles = geth.PrecompiledContractsBerlin
+	default: // Istanbul is the oldest supported revision supported by Sonic
+		precompiles = geth.PrecompiledContractsIstanbul
 	}
-	return 1 <= recipient[19] && recipient[19] <= 9
+
+	_, ok := precompiles[common.Address(recipient)]
+	return ok
 }

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -299,14 +299,19 @@ func TestRunContextAdapter_Call(t *testing.T) {
 	canTransfer := func(geth.StateDB, common.Address, *uint256.Int) bool { return true }
 	transfer := func(geth.StateDB, common.Address, common.Address, *uint256.Int) {}
 
+	chainConfig := &params.ChainConfig{
+		ChainID:       big.NewInt(42),
+		IstanbulBlock: big.NewInt(24),
+	}
+	blockContext := geth.BlockContext{
+		CanTransfer: canTransfer,
+		Transfer:    transfer,
+		BlockNumber: big.NewInt(24),
+	}
+	evm := geth.NewEVM(blockContext, stateDb, chainConfig, geth.Config{})
+
 	runContextAdapter := &runContextAdapter{
-		evm: &geth.EVM{
-			StateDB: stateDb,
-			Context: geth.BlockContext{
-				CanTransfer: canTransfer,
-				Transfer:    transfer,
-			},
-		},
+		evm:    evm,
 		caller: address,
 	}
 
@@ -738,7 +743,7 @@ func TestAdapter_ReadOnlyIsSetAndResetCorrectly(t *testing.T) {
 	gas := uint64(42)
 	for name, readOnly := range tests {
 		t.Run(name, func(t *testing.T) {
-			setGas := encodeReadOnlyInGas(gas, recipient, readOnly)
+			setGas := encodeReadOnlyInGas(gas, recipient, tosca.R07_Istanbul, readOnly)
 			gotReadOnly, unsetGas := decodeReadOnlyFromGas(depth, readOnly, setGas)
 
 			if unsetGas != gas {
@@ -792,4 +797,56 @@ func TestGethInterpreterAdapter_RefundShiftIsReverted(t *testing.T) {
 			undoRefundShift(stateDb, test.err, shift)
 		})
 	}
+}
+
+func TestGethAdapter_IsPrecompiledContractDependsOnRevision(t *testing.T) {
+	tests := map[string]struct {
+		revision        tosca.Revision
+		lastPrecompiled int
+	}{
+		"istanbul": {
+			revision:        tosca.R07_Istanbul,
+			lastPrecompiled: 9,
+		},
+		"berlin": {
+			revision:        tosca.R09_Berlin,
+			lastPrecompiled: 9,
+		},
+		"london": {
+			revision:        tosca.R10_London,
+			lastPrecompiled: 9,
+		},
+		"paris": {
+			revision:        tosca.R11_Paris,
+			lastPrecompiled: 9,
+		},
+		"shanghai": {
+			revision:        tosca.R12_Shanghai,
+			lastPrecompiled: 9,
+		},
+		"cancun": {
+			revision:        tosca.R13_Cancun,
+			lastPrecompiled: 10,
+		},
+		"prague": {
+			revision:        tosca.R14_Prague,
+			lastPrecompiled: 17,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for i := 1; i < 100; i++ {
+				address := uint256.NewInt(uint64(i)).Bytes20()
+				got := isPrecompiledContract(address, test.revision)
+				if i <= test.lastPrecompiled && !got {
+					t.Errorf("Expected %v to be precompiled, got %v", address, got)
+				}
+				if i > test.lastPrecompiled && got {
+					t.Errorf("Expected %v to not be precompiled, got %v", address, got)
+				}
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
The readOnly flag is passed to geth using the msb of the gas. In case of a call to a precompiled contract this can not be done. The function which checks if the address is a precompiled contract has not been updated for revisions newer than Shanghai. 