### PR TITLE
Update linters to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+version: "2"
+linters:
+  settings:
+    staticcheck:
+      initialisms: []
+      dot-import-whitelist: []
+      http-status-code-whitelist: []
+      checks:
+        - all
+        # default ignored checks
+        - "-ST1000" # Invalid regular expression.
+        - "-ST1003" # Unsupported argument to functions in 'encoding/binary'.
+        - "-ST1016" # Trapping a signal that cannot be trapped.
+        - "-ST1020" # Using an invalid host:port pair with a 'net.Listen'-related function.
+        - "-ST1021" # Using 'bytes.Equal' to compare two 'net.IP'.
+        - "-ST1022" #
+
+formatters:
+  # Enable specific formatter.
+  # Default: [] (uses standard Go formatting)
+  enable:
+    - gofmt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,17 +49,9 @@ pipeline {
             }
         }
 
-        stage('Check Go sources formatting') {
+        stage('Check Go formatting and lint Go sources') {
             steps {
-                sh "gofmt -s -d go"
-            }
-        }
-
-        stage('Lint Go sources') {
-            steps {
-                withEnv(["PATH+GOPATH=${env.HOME}/go/bin"]) {
                     sh 'make lint-go'
-                }
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ ct-coverage-geth: EXTRA_PACKAGES=github.com/ethereum/go-ethereum/core/vm/...
 ct-coverage-geth: ct-coverage-go
 
 ct-coverage-evmzero: tosca-cpp-coverage
-ct-coverage-evmzero: 
+ct-coverage-evmzero:
 	go run ./go/ct/driver run evmzero ; \
 	echo "Coverage report generated in cpp/build/coverage/index.html"
 	@cd cpp/build ; \
-	cmake --build .  --target coverage 
+	cmake --build .  --target coverage
 
 test: test-go test-cpp test-rust
 
@@ -94,15 +94,15 @@ test-cpp-asan: TOSCA_CPP_BUILD = Debug
 test-cpp-asan: TOSCA_CPP_ASAN = ON
 test-cpp-asan: test-cpp
 
-cpp-coverage-report: 
+cpp-coverage-report:
 	@cd cpp/build ; \
-	cmake --build .  --target coverage 
+	cmake --build .  --target coverage
 
 test-cpp-coverage: TOSCA_CPP_BUILD = Debug
 test-cpp-coverage: TOSCA_CPP_COVERAGE = ON
 test-cpp-coverage: test-cpp
 	@cd cpp/build ; \
-	cmake --build .  --target coverage 
+	cmake --build .  --target coverage
 
 bench: TOSCA_CPP_ASSERT = OFF
 bench: tosca-cpp bench-go
@@ -145,17 +145,5 @@ coverage-report:
 	@go install github.com/vladopajic/go-test-coverage/v2@v2.10.1
 	@go-test-coverage --config .testcoverage.yml
 
-# Linting
-
-vet:
-	go vet ./go/...
-
-staticcheck: 
-	@go install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
-	staticcheck ./go/...
-
-errorcheck:
-	@go install github.com/kisielk/errcheck@$(ERRCHECK_VERSION)
-	errcheck ./go/...
-
-lint-go: vet staticcheck errorcheck
+lint-go:
+	golangci-lint run ./go/...


### PR DESCRIPTION
This PR consolidates linters and use the meta linter, golangci-lint instead.  A base configuration of golangci-lint is added. It should be adjusted as needed.