### PR TITLE
Add golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,44 @@
+version: "2"
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+        # Ignored rules
+        - "-ST1000" # Incorrect or missing package comment.
+        - "-ST1003" # Poorly chosen identifier.
+        # rules ST1023 and QF1011 have few findings, but in those cases adding
+        # the type to the declaration improves readability.
+        - "-ST1023" # Redundant type in variable declaration.
+        - "-QF1011" # Omit redundant type from variable declaration.
+
+
+formatters:
+  # Enable specific formatter.
+  enable:
+    - gofmt
+
+issues:
+  # do not limit number of findings per linter
+  max-issues-per-linter: 0
+  # do not limit number of same finding
+  max-same-issues: 0
+  # do not limit number of issues per line
+  uniq-by-line: false
+
+output:
+  formats:
+    text:
+      # for CI or automated processing
+      path: ./build/golangci-lint-report.txt
+    html:
+      # for human consumption
+      path: ./build/golangci-lint-report.html

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,13 @@
+# Copyright (c) 2024 Fantom Foundation
+#
+# Use of this software is governed by the Business Source License included
+# in the LICENSE file and at fantom.foundation/bsl11.
+#
+# Change Date: 2028-4-16
+#
+# On the date above, in accordance with the Business Source License, use of
+# this software will be governed by the GNU Lesser General Public License v3.
+
 version: "2"
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,11 @@ linters:
         # the type to the declaration improves readability.
         - "-ST1023" # Redundant type in variable declaration.
         - "-QF1011" # Omit redundant type from variable declaration.
+        # rule ST1001 reports mostly dot imports of the `common` package, which is broadly used
+        # in the codebase, so it improves readability to keep it.
+        # The other report is for package `rlz` in specification.go, which is broadly used
+        # in that file, so it improves readability to keep it.
+        - "-ST1001" # should not use dot imports
 
 
 formatters:
@@ -42,3 +47,5 @@ output:
     html:
       # for human consumption
       path: ./build/golangci-lint-report.html
+    tab:
+      path: stdout

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,17 +49,9 @@ pipeline {
             }
         }
 
-        stage('Check Go sources formatting') {
+        stage('Check Go formatting and lint Go sources') {
             steps {
-                sh "gofmt -s -d go"
-            }
-        }
-
-        stage('Lint Go sources') {
-            steps {
-                withEnv(["PATH+GOPATH=${env.HOME}/go/bin"]) {
                     sh 'make lint-go'
-                }
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ ct-coverage-geth: EXTRA_PACKAGES=github.com/ethereum/go-ethereum/core/vm/...
 ct-coverage-geth: ct-coverage-go
 
 ct-coverage-evmzero: tosca-cpp-coverage
-ct-coverage-evmzero: 
+ct-coverage-evmzero:
 	go run ./go/ct/driver run evmzero ; \
 	echo "Coverage report generated in cpp/build/coverage/index.html"
 	@cd cpp/build ; \
-	cmake --build .  --target coverage 
+	cmake --build .  --target coverage
 
 test: test-go test-cpp test-rust
 
@@ -94,15 +94,15 @@ test-cpp-asan: TOSCA_CPP_BUILD = Debug
 test-cpp-asan: TOSCA_CPP_ASAN = ON
 test-cpp-asan: test-cpp
 
-cpp-coverage-report: 
+cpp-coverage-report:
 	@cd cpp/build ; \
-	cmake --build .  --target coverage 
+	cmake --build .  --target coverage
 
 test-cpp-coverage: TOSCA_CPP_BUILD = Debug
 test-cpp-coverage: TOSCA_CPP_COVERAGE = ON
 test-cpp-coverage: test-cpp
 	@cd cpp/build ; \
-	cmake --build .  --target coverage 
+	cmake --build .  --target coverage
 
 bench: TOSCA_CPP_ASSERT = OFF
 bench: tosca-cpp bench-go
@@ -145,17 +145,5 @@ coverage-report:
 	@go install github.com/vladopajic/go-test-coverage/v2@v2.10.1
 	@go-test-coverage --config .testcoverage.yml
 
-# Linting
-
-vet:
-	go vet ./go/...
-
-staticcheck: 
-	@go install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
-	staticcheck ./go/...
-
-errorcheck:
-	@go install github.com/kisielk/errcheck@$(ERRCHECK_VERSION)
-	errcheck ./go/...
-
-lint-go: vet staticcheck errorcheck
+lint-go:
+	golangci-lint run ./go/...

--- a/Makefile
+++ b/Makefile
@@ -146,4 +146,5 @@ coverage-report:
 	@go-test-coverage --config .testcoverage.yml
 
 lint-go:
-	golangci-lint run ./go/...
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+	@golangci-lint run ./go/...

--- a/go/ct/spc/staticcheck.conf
+++ b/go/ct/spc/staticcheck.conf
@@ -1,4 +1,0 @@
-dot_import_whitelist = [
-    "github.com/0xsoniclabs/tosca/go/ct/common",
-    "github.com/0xsoniclabs/tosca/go/ct/rlz",
-]

--- a/go/ct/staticcheck.conf
+++ b/go/ct/staticcheck.conf
@@ -1,1 +1,0 @@
-dot_import_whitelist = ["github.com/0xsoniclabs/tosca/go/ct/common"]


### PR DESCRIPTION
This PR introduces `golangci-lint` which is a go linters runner. Linters which are enabled includes:
- errcheck
- govet
- ineffassign
- misspell
- staticcheck
- unused

The linters currently used in Tosca are errcheck, govet, staticcheck. 

`Jenkinsfile` now calls to `make lint-go`
`make lint-go` now uses golangci.

This PR will remain a draft untill 