### PR TITLE
Fix typo and ineffectual assignment

### DIFF
--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -187,7 +187,7 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 	// Build random code incrementally.
 	for i := 0; i < size; i++ {
 		// Pick the next operation.
-		op := vm.INVALID
+		var op vm.OpCode
 		nextFixedPosition := ops[0].pos
 		if nextFixedPosition < i {
 			return nil, fmt.Errorf(

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -2279,7 +2279,7 @@ func selfDestructEffect(s *st.State) {
 		s.Accounts.MarkWarm(beneficiaryAccount)
 	}
 
-	// Add costs for transfering the remaining balance.
+	// Add costs for transferring the remaining balance.
 	if !originatorBalance.IsZero() {
 		// If the target account is empty, the account creation fee is added.
 		if s.Accounts.IsEmpty(beneficiaryAccount) {


### PR DESCRIPTION
This PR fixes 2 findings, one of ineffective assigns and the other a misspelling typo, both from linters to be added by https://github.com/0xsoniclabs/tosca/pull/86.

ineffective assign analysis: 
the flagged assignment is `op := vm.INVALID` in `go/ct/gen/code.go:190`, at the beginning of a `for` loop.
if `nextFixedPosition < i` then the function exits, and does not return nor uses `op` 
if `i == nextFixedPosition` then the first thing it does is to assings a new value to `op`
if `i != nextFixedPosition` then a limit variable is calculated and after assigns `op = vm.OpCode(rnd.Int())` before using it.

given that the last 2 conditions are `if {} else {}` op will always be assigned before being used, rendering the initial assignment ineffectual. 