### PR TITLE
Fix documentation of exported methods

### DIFF
--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -142,7 +142,7 @@ func (g *StateGenerator) BindPc(pc Variable) {
 	}
 }
 
-// BindToAccountAddress constraints the given variable to be mapped to the
+// BindToSelfAddress constraints the given variable to be mapped to the
 // address of the account that is executing the code.
 func (g *StateGenerator) BindToSelfAddress(address Variable) {
 	if !slices.Contains(g.selfAddressBindings, address) {
@@ -271,13 +271,13 @@ func (g *StateGenerator) BindToAddressOfNonEmptyAccount(address Variable) {
 	g.accountsGen.BindToAddressOfNonEmptyAccount(address)
 }
 
-// AddMinimumBalance adds a constraint restricting the balance of the account
+// AddBalanceLowerBound adds a constraint restricting the balance of the account
 // identified by the given variable to be at least the given value.
 func (g *StateGenerator) AddBalanceLowerBound(address Variable, value U256) {
 	g.accountsGen.AddBalanceLowerBound(address, value)
 }
 
-// AddMinimumBalance adds a constraint restricting the balance of the account
+// AddBalanceUpperBound adds a constraint restricting the balance of the account
 // identified by the given variable to be at most the given value.
 func (g *StateGenerator) AddBalanceUpperBound(address Variable, value U256) {
 	g.accountsGen.AddBalanceUpperBound(address, value)

--- a/go/ct/gen/storage.go
+++ b/go/ct/gen/storage.go
@@ -44,7 +44,7 @@ func (a *storageConfigConstraint) Less(b *storageConfigConstraint) bool {
 	return a.newValue < b.newValue
 }
 
-// Check checks if the given storage configuration (org,cur,new) corresponds to
+// CheckStorageStatusConfig checks if the given storage configuration (org,cur,new) corresponds to
 // the wanted config.
 func CheckStorageStatusConfig(config tosca.StorageStatus, org, cur, new U256) bool {
 	return config == tosca.GetStorageStatus(

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -1061,7 +1061,7 @@ type containsDelegationDesignation struct {
 	state   DelegationDesignatorState
 }
 
-// DelegationDesignatorState is a condition where the Code of the account
+// ConstraintDelegationDesignator is a condition where the Code of the account
 // at the given address has designator to a warm delegate, a cold delegate or
 // no delegate at all.
 // see https://eips.ethereum.org/EIPS/eip-7702

--- a/go/examples/example.go
+++ b/go/examples/example.go
@@ -100,7 +100,7 @@ func (e *Example) RunOnProcessor(processor tosca.Processor, argument int,
 	}, nil
 }
 
-// RunRef runs the reference function of this example to produce the expected result.
+// RunReference runs the reference function of this example to produce the expected result.
 func (e *Example) RunReference(argument int) int {
 	return e.reference(argument)
 }

--- a/go/examples/static_overhead.go
+++ b/go/examples/static_overhead.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
-// Create arguments for the interpreter that outline the worst case when calling the
+// GetStaticOverheadExample creates arguments for the interpreter that outline the worst case when calling the
 // interpreter with short running contracts. In particular those arguments try to trigger
 // all possible allocations that happen when using an evmc interpreter which needs to copy data
 // into new allocations.

--- a/go/tosca/vm/opcodes.go
+++ b/go/tosca/vm/opcodes.go
@@ -176,7 +176,7 @@ func (op OpCode) Width() int {
 	}
 }
 
-// OpCodesNoPush returns a slice of valid op codes, but no PUSH instruction.
+// ValidOpCodesNoPush returns a slice of valid op codes, but no PUSH instruction.
 func ValidOpCodesNoPush() []OpCode {
 	res := make([]OpCode, 0, 256)
 	for i := 0; i < 256; i++ {


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule ST1020.
This rule enforces that the documentation, if any, of an exported method must begin with the name of the method.
This rule will be activated with https://github.com/0xsoniclabs/tosca/pull/86