### PR TITLE
Fix documentation of exported structs

### DIFF
--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -46,7 +46,7 @@ type Expression[T any] interface {
 	fmt.Stringer
 }
 
-// Bindable is an Expression that can be referenced as a Variable.
+// BindableExpression is an Expression that can be referenced as a Variable.
 type BindableExpression[T any] interface {
 	// GetVariable returns the variable referring to this Expression.
 	GetVariable() gen.Variable

--- a/go/integration_test/interpreter/dynamic_gas.go
+++ b/go/integration_test/interpreter/dynamic_gas.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-// Structure for dynamic gas instruction test
+// DynGasTest is a structure for dynamic gas instruction test
 type DynGasTest struct {
 	testName       string                  // test name
 	stackValues    []*big.Int              // values to be put on stack
@@ -29,7 +29,7 @@ type DynGasTest struct {
 	memValues      []*big.Int
 }
 
-// Structure for dynamic gas instruction test
+// FailGasTest is a structure for dynamic gas instruction test
 type FailGasTest struct {
 	testName    string                  // test name
 	instruction vm.OpCode               // tested instruction opcode

--- a/go/tosca/interpreter.go
+++ b/go/tosca/interpreter.go
@@ -194,7 +194,7 @@ const (
 	numRevisions int = iota
 )
 
-// Error for runs with unsupported Revision
+// ErrUnsupportedRevision is an error for runs with unsupported Revision
 type ErrUnsupportedRevision struct {
 	Revision Revision
 }


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule ST1021.
This rule enforces that the documentation, if any, of an exported struct must begin with the name of the struct.
This rule will be activated with https://github.com/0xsoniclabs/tosca/pull/86