### PR TITLE
Apply DeMorgan's law

### DIFF
--- a/go/ct/gen/block_context_test.go
+++ b/go/ct/gen/block_context_test.go
@@ -283,7 +283,7 @@ func TestBlockContextGenerator_CanProduceSatisfyingBlockNumbersForConstraints(t 
 				a["a"] = common.NewU256(800)
 			},
 			check: func(t *testing.T, res st.BlockContext, a Assignment) {
-				if !(800 < res.BlockNumber && res.BlockNumber < 1000) {
+				if res.BlockNumber < 801 || 1000 < res.BlockNumber {
 					t.Errorf("expected block number to be in range 801-1000, got %d", res.BlockNumber)
 				}
 			},
@@ -299,8 +299,8 @@ func TestBlockContextGenerator_CanProduceSatisfyingBlockNumbersForConstraints(t 
 				} else if !value.IsUint64() {
 					// this is fine, the value is out of range
 				} else {
-					value := value.Uint64()
-					if !(res.BlockNumber-value > 256 || res.BlockNumber-value < 1) {
+					want := res.BlockNumber - value.Uint64()
+					if 1 <= want && want <= 256 {
 						t.Errorf("unexpected distance between variable 'a' and block number, got block number %d and assignment %d", res.BlockNumber, value)
 					}
 				}

--- a/go/ct/gen/range_solver.go
+++ b/go/ct/gen/range_solver.go
@@ -60,7 +60,7 @@ func (s *RangeSolver[T]) AddEqualityConstraint(value T) {
 }
 
 func (s *RangeSolver[T]) IsSatisfiable() bool {
-	return !(s.min > s.max)
+	return s.min <= s.max
 }
 
 func (s *RangeSolver[T]) Clone() *RangeSolver[T] {

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -262,7 +262,7 @@ func (c *gt[T]) Check(s *st.State) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return !(domain.Less(lhs, c.rhs) || domain.Equal(lhs, c.rhs)), nil
+	return !domain.Less(lhs, c.rhs) && !domain.Equal(lhs, c.rhs), nil
 }
 
 func (c *gt[T]) Restrict(generator *gen.StateGenerator) {


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule `QF1001`.
This rule reports possible applications of [De Morgan's Law](https://en.wikipedia.org/wiki/De_Morgan%27s_laws).
In particular, there is only one reported finding, in a test for of version number ordering, where a positive proposition is preferred.

This rule will be activated with https://github.com/0xsoniclabs/tosca/pull/86