### PR TITLE
Replace `strings.Replace` with `strings.ReplaceAll`

### DIFF
--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -2522,7 +2522,7 @@ func getRulesForCall(op vm.OpCode, revision tosca.Revision, warm, zeroValue bool
 		valueZeroConditionName,
 		delegationDesignator.String(),
 	}, "_")
-	name = strings.Replace(name, "__", "_", -1)
+	name = strings.ReplaceAll(name, "__", "_")
 
 	return rulesFor(instruction{
 		op:         op,


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule `QF1004`.
This rule reports uses of `strings.Replace` when the last argument is `-1` means it should replace all occurrences. Instead the method `strings.ReplaceAll` should be call, as it show in clearer manner the intent.

This rule will be activated with #86 