### PR TITLE
Elevate if+break to loop condition

### DIFF
--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -486,7 +486,7 @@ func (s *varCodeConstraintSolver) solveIsData(varIsDataConstraints []varIsDataCo
 		startPos := pos
 		pushOp := vm.PUSH1
 
-		// if we are on data already, use this position
+		// if we are on data, use this position
 		for s.usedPositions[pos] != isData {
 
 			if s.usedPositions[pos] == isUnused {


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule `QF1006`.
This rule reports locations where an if+break is used as first statement inside a for loop. In some cases the condition of the if can be moved into the iteration condition of the for.

This rule will be activated with #86 