### PR TITLE
Remove unnecessary embedded fields

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -109,7 +109,7 @@ func (a *gethInterpreterAdapter) Run(contract *geth.Contract, input []byte, read
 	if err != nil {
 		return nil, fmt.Errorf("could not convert blob-base fee: %v", err)
 	}
-	gasPrice, err := bigIntToValue(a.evm.TxContext.GasPrice)
+	gasPrice, err := bigIntToValue(a.evm.GasPrice)
 	if err != nil {
 		return nil, fmt.Errorf("could not convert gas price: %v", err)
 	}

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -489,18 +489,18 @@ func TestRunContextAdapter_Run(t *testing.T) {
 			interpreter.EXPECT().Run(gomock.Any()).DoAndReturn(func(params tosca.Parameters) (tosca.Result, error) {
 				// The parameters save the context as a pointer, its value can
 				// not be predicted during the setup phase of the mock.
-				if expectedParams.BlockParameters.ChainID != params.BlockParameters.ChainID ||
-					expectedParams.BlockParameters.BlockNumber != params.BlockParameters.BlockNumber ||
-					expectedParams.BlockParameters.Timestamp != params.BlockParameters.Timestamp ||
-					expectedParams.BlockParameters.Coinbase != params.BlockParameters.Coinbase ||
-					expectedParams.BlockParameters.GasLimit != params.BlockParameters.GasLimit ||
-					expectedParams.BlockParameters.PrevRandao != params.BlockParameters.PrevRandao ||
-					expectedParams.BlockParameters.BaseFee != params.BlockParameters.BaseFee ||
-					expectedParams.BlockParameters.BlobBaseFee != params.BlockParameters.BlobBaseFee ||
-					expectedParams.BlockParameters.Revision != params.BlockParameters.Revision ||
-					expectedParams.TransactionParameters.Origin != params.TransactionParameters.Origin ||
-					expectedParams.TransactionParameters.GasPrice != params.TransactionParameters.GasPrice ||
-					!slices.Equal(expectedParams.TransactionParameters.BlobHashes, params.TransactionParameters.BlobHashes) ||
+				if expectedParams.ChainID != params.ChainID ||
+					expectedParams.BlockNumber != params.BlockNumber ||
+					expectedParams.Timestamp != params.Timestamp ||
+					expectedParams.Coinbase != params.Coinbase ||
+					expectedParams.GasLimit != params.GasLimit ||
+					expectedParams.PrevRandao != params.PrevRandao ||
+					expectedParams.BaseFee != params.BaseFee ||
+					expectedParams.BlobBaseFee != params.BlobBaseFee ||
+					expectedParams.Revision != params.Revision ||
+					expectedParams.Origin != params.Origin ||
+					expectedParams.GasPrice != params.GasPrice ||
+					!slices.Equal(expectedParams.BlobHashes, params.BlobHashes) ||
 					expectedParams.Kind != params.Kind ||
 					expectedParams.Static != params.Static ||
 					expectedParams.Depth != params.Depth ||

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -507,7 +507,7 @@ func TestSteps_StaticContextViolation(t *testing.T) {
 				Code:   []byte{0x0},
 			}
 			ctxt.code = []Instruction{{test.op, 0}}
-			ctxt.params.BlockParameters.Revision = test.minRevision
+			ctxt.params.Revision = test.minRevision
 
 			if len(test.stack) == 0 {
 				// add enough stack elements to pass stack bounds check
@@ -558,7 +558,7 @@ func TestInterpreter_InstructionsFailWhenExecutedInRevisionsEarlierThanIntroduce
 			t.Run(fmt.Sprintf("%v/%v", op, revision), func(t *testing.T) {
 				ctxt := getEmptyContext()
 				ctxt.code = []Instruction{{op, 0}}
-				ctxt.params.BlockParameters.Revision = revision
+				ctxt.params.Revision = revision
 				ctxt.stack.stackPointer = 20
 
 				_, err := steps(&ctxt, false)

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -25,7 +25,7 @@ func TestNewInterpreter_ProducesInstanceWithSanctionedProperties(t *testing.T) {
 	if lfvm.config.WithShaCache != true {
 		t.Fatalf("LFVM is not configured with sha cache")
 	}
-	if lfvm.config.ConversionConfig.WithSuperInstructions != false {
+	if lfvm.config.WithSuperInstructions != false {
 		t.Fatalf("LFVM is configured with super instructions")
 	}
 }
@@ -42,7 +42,7 @@ func TestLfvm_OfficialConfigurationHasSanctionedProperties(t *testing.T) {
 	if lfvm.config.WithShaCache != true {
 		t.Fatalf("lfvm is not configured with sha cache")
 	}
-	if lfvm.config.ConversionConfig.WithSuperInstructions != false {
+	if lfvm.config.WithSuperInstructions != false {
 		t.Fatalf("lfvm is configured with super instructions")
 	}
 }


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule `QF1008`.
In `Go` when a `struct` has an *embedded* field, it allows the outer struct to call on methods and fields of the inner one, without actually naming the embedded struct.
This rule reports those cases where calling the embedded field can be omitted to simply call its methods.

This rule will be activated with https://github.com/0xsoniclabs/tosca/pull/86