### PR TITLE
Fix static check QF1012

### DIFF
--- a/go/interpreter/lfvm/instruction_logger.go
+++ b/go/interpreter/lfvm/instruction_logger.go
@@ -38,7 +38,7 @@ func (l loggingRunner) run(c *context) (status, error) {
 				top = c.stack.peek().ToBig().String()
 			}
 			if l.log != nil {
-				_, err = l.log.Write([]byte(fmt.Sprintf("%v, %d, %v\n", c.code[c.pc].opcode, c.gas, top)))
+				_, err = fmt.Fprintf(l.log, "%v, %d, %v\n", c.code[c.pc].opcode, c.gas, top)
 				if err != nil {
 					return status, err
 				}


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule `QF1012`.
This rule reports when a call to a `Writer` contains a call to `fmt.Sprintf` and suggests its replacement by `fmt.Fprintf(writer, ...)`. 

This rule will be activated with https://github.com/0xsoniclabs/tosca/pull/86