### PR TITLE
Fix reporting of errors to EVMC host context

### DIFF
--- a/go/interpreter/evmc/evmc_interpreter.go
+++ b/go/interpreter/evmc/evmc_interpreter.go
@@ -308,7 +308,7 @@ func (ctx *hostContext) Call(kind evmc.CallKind, recipient evmc.Address, sender 
 
 	result, err := ctx.context.Call(callKind, params)
 	if err != nil {
-		return nil, 0, 0, evmc.Address{}, err
+		return nil, 0, 0, evmc.Address{}, evmc.Failure
 	}
 	if !result.Success {
 		err = evmc.Revert


### PR DESCRIPTION
The Go bindings of the [EVMC](https://github.com/ethereum/evmc) package [require](https://github.com/ethereum/evmc/blob/496ce0f81058378b72d0b592d1c49b935bce3302/bindings/go/evmc/host.go#L230)  [Error](https://github.com/ethereum/evmc/blob/496ce0f81058378b72d0b592d1c49b935bce3302/bindings/go/evmc/evmc.go#L82)s of a specific type to be reported upon calls. 

So far, this was only correctly reported in case of a revert. In other cases, an arbitrary error was reported, leading to a type-casting failure in the EVMC binding if such an error is emitted. This change is returning a generic `Failure` error in all other cases.