### PR TITLE
Geth adapter: Gas refund end to end test

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -237,6 +237,9 @@ func undoRefundShift(stateDB geth.StateDB, err error, refundShift uint64) {
 			shift = cur
 		}
 		stateDB.SubRefund(shift)
+	} else {
+		// In the case of an error, the refund is set to zero
+		stateDB.SubRefund(stateDB.GetRefund())
 	}
 }
 

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -1123,7 +1123,7 @@ func (s *stateDBMockWorkingRefund) SubRefund(refund uint64) {
 	}
 }
 
-func TestGethAdapter_RefundShiftEndToEndTest(t *testing.T) {
+func TestGethAdapter_RefundShiftIsAlwaysUndone(t *testing.T) {
 	tests := map[string]struct {
 		success   bool
 		gasRefund tosca.Gas
@@ -1143,6 +1143,11 @@ func TestGethAdapter_RefundShiftEndToEndTest(t *testing.T) {
 			success:   false,
 			gasRefund: 1000,
 			refund:    0, // On failure, refund should be reset to 0
+		},
+		"failureNegativeRefund": {
+			success:   false,
+			gasRefund: -1000,
+			refund:    0, // Negative refund on failure should also reset to 0
 		},
 	}
 

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -1125,29 +1125,29 @@ func (s *stateDBMockWorkingRefund) SubRefund(refund uint64) {
 
 func TestGethAdapter_RefundShiftIsAlwaysUndone(t *testing.T) {
 	tests := map[string]struct {
-		success   bool
-		gasRefund tosca.Gas
-		refund    uint64
+		success        bool
+		gasRefund      tosca.Gas
+		reportedRefund uint64
 	}{
 		"success": {
-			success:   true,
-			gasRefund: 1000,
-			refund:    1000,
+			success:        true,
+			gasRefund:      1000,
+			reportedRefund: 1000,
 		},
 		"successNegativeRefund": {
-			success:   true,
-			gasRefund: -1000,
-			refund:    0, // Negative refund should not be added
+			success:        true,
+			gasRefund:      -1000,
+			reportedRefund: 0, // Negative refund should not be added
 		},
 		"failure": {
-			success:   false,
-			gasRefund: 1000,
-			refund:    0, // On failure, refund should be reset to 0
+			success:        false,
+			gasRefund:      1000,
+			reportedRefund: 0, // On failure, refund should be reset to 0
 		},
 		"failureNegativeRefund": {
-			success:   false,
-			gasRefund: -1000,
-			refund:    0, // Negative refund on failure should also reset to 0
+			success:        false,
+			gasRefund:      -1000,
+			reportedRefund: 0, // Negative refund on failure should also reset to 0
 		},
 	}
 
@@ -1181,8 +1181,8 @@ func TestGethAdapter_RefundShiftIsAlwaysUndone(t *testing.T) {
 			}
 
 			refund := stateDb.GetRefund()
-			if refund != test.refund {
-				t.Errorf("Expected refund %d, got %d", test.refund, refund)
+			if refund != test.reportedRefund {
+				t.Errorf("Expected refund %d, got %d", test.reportedRefund, refund)
 			}
 		})
 	}

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -523,6 +523,9 @@ func TestRunContextAdapter_Run(t *testing.T) {
 				stateDb.EXPECT().AddRefund(uint64(0))
 				stateDb.EXPECT().GetRefund().Return(refundShift)
 				stateDb.EXPECT().SubRefund(refundShift)
+			} else {
+				stateDb.EXPECT().GetRefund()
+				stateDb.EXPECT().SubRefund(uint64(0))
 			}
 
 			contract := geth.NewContract(common.Address(address), common.Address(address), nil, 0, nil)
@@ -595,6 +598,8 @@ func TestGethAdapter_CorruptValuesReturnErrors(t *testing.T) {
 			}
 
 			stateDb.EXPECT().AddRefund(gomock.Any())
+			stateDb.EXPECT().GetRefund()
+			stateDb.EXPECT().SubRefund(gomock.Any())
 
 			address := tosca.Address{0x42}
 			contract := geth.NewContract(common.Address(address), common.Address(address), nil, 0, nil)
@@ -1034,6 +1039,9 @@ func TestGethInterpreterAdapter_RefundShiftIsReverted(t *testing.T) {
 			if test.err == nil {
 				stateDb.EXPECT().GetRefund().Return(test.refund)
 				stateDb.EXPECT().SubRefund(expectedSub)
+			} else {
+				stateDb.EXPECT().GetRefund().Return(test.refund)
+				stateDb.EXPECT().SubRefund(test.refund)
 			}
 
 			undoRefundShift(stateDb, test.err, shift)
@@ -1090,7 +1098,89 @@ func TestGethAdapter_IsPrecompiledContractDependsOnRevision(t *testing.T) {
 			}
 		})
 	}
+}
 
+// stateDBMockWorkingRefund is a mock implementation of the StateDb interface
+// that simulates a working refund mechanism for testing purposes.
+type stateDBMockWorkingRefund struct {
+	*MockStateDb
+	refund uint64
+}
+
+func (s *stateDBMockWorkingRefund) GetRefund() uint64 {
+	return s.refund
+}
+
+func (s *stateDBMockWorkingRefund) AddRefund(refund uint64) {
+	s.refund += refund
+}
+
+func (s *stateDBMockWorkingRefund) SubRefund(refund uint64) {
+	if refund > s.refund {
+		s.refund = 0
+	} else {
+		s.refund -= refund
+	}
+}
+
+func TestGethAdapter_RefundShiftEndToEndTest(t *testing.T) {
+	tests := map[string]struct {
+		success   bool
+		gasRefund tosca.Gas
+		refund    uint64
+	}{
+		"success": {
+			success:   true,
+			gasRefund: 1000,
+			refund:    1000,
+		},
+		"successNegativeRefund": {
+			success:   true,
+			gasRefund: -1000,
+			refund:    0, // Negative refund should not be added
+		},
+		"failure": {
+			success:   false,
+			gasRefund: 1000,
+			refund:    0, // On failure, refund should be reset to 0
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			interpreter := tosca.NewMockInterpreter(ctrl)
+
+			stateDb := &stateDBMockWorkingRefund{
+				MockStateDb: NewMockStateDb(ctrl),
+				refund:      0,
+			}
+
+			chainId := int64(42)
+			blockNumber := int64(24)
+			address := tosca.Address{0x42}
+
+			blockParameters := geth.BlockContext{BlockNumber: big.NewInt(blockNumber)}
+			chainConfig := &params.ChainConfig{ChainID: big.NewInt(chainId), IstanbulBlock: big.NewInt(23)}
+			evm := geth.NewEVM(blockParameters, stateDb, chainConfig, geth.Config{})
+			adapter := &gethInterpreterAdapter{
+				evm:         evm,
+				interpreter: interpreter,
+			}
+
+			contract := geth.NewContract(common.Address(address), common.Address(address), nil, 0, nil)
+			interpreter.EXPECT().Run(gomock.Any()).Return(tosca.Result{Success: test.success, GasRefund: test.gasRefund}, nil)
+			_, err := adapter.Run(contract, []byte{}, false)
+			if test.success && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			refund := stateDb.GetRefund()
+			if refund != test.refund {
+				t.Errorf("Expected refund %d, got %d", test.refund, refund)
+			}
+		})
+	}
 }
 
 func newEVMWithPassingChainConfig() *geth.EVM {


### PR DESCRIPTION
This PR adds an end to end test for the gas refund handling in the geth adapter by simulating the refund logic of the stateDb.