### PR TITLE
Processor: Add prague support

### DIFF
--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -101,32 +101,34 @@ func (m *gethVm) Run(parameters tosca.Parameters) (tosca.Result, error) {
 // chainId needs to be prefilled as it may be accessed with the opcode CHAINID.
 // the fork-blocks and the fork-times are set to the respective values for the given revision.
 func MakeChainConfig(baseline params.ChainConfig, chainId *big.Int, targetRevision tosca.Revision) params.ChainConfig {
-	istanbulBlock := ct.GetForkBlock(tosca.R07_Istanbul)
-	berlinBlock := ct.GetForkBlock(tosca.R09_Berlin)
-	londonBlock := ct.GetForkBlock(tosca.R10_London)
-	parisBlock := ct.GetForkBlock(tosca.R11_Paris)
-	shanghaiTime := ct.GetForkTime(tosca.R12_Shanghai)
-	cancunTime := ct.GetForkTime(tosca.R13_Cancun)
-	pragueTime := ct.GetForkTime(tosca.R14_Prague)
+	maxUintBlock := big.NewInt(0).SetUint64(^uint64(0))
+	zeroTime := uint64(0)
 
 	chainConfig := baseline
 	chainConfig.ChainID = chainId
 	chainConfig.ByzantiumBlock = big.NewInt(0)
-	chainConfig.IstanbulBlock = big.NewInt(0).SetUint64(istanbulBlock)
-	chainConfig.BerlinBlock = big.NewInt(0).SetUint64(berlinBlock)
-	chainConfig.LondonBlock = big.NewInt(0).SetUint64(londonBlock)
+	chainConfig.IstanbulBlock = big.NewInt(0)
+	chainConfig.BerlinBlock = maxUintBlock
+	chainConfig.LondonBlock = maxUintBlock
+	chainConfig.MergeNetsplitBlock = maxUintBlock
 
+	if targetRevision >= tosca.R09_Berlin {
+		chainConfig.BerlinBlock = big.NewInt(0)
+	}
+	if targetRevision >= tosca.R10_London {
+		chainConfig.LondonBlock = big.NewInt(0)
+	}
 	if targetRevision >= tosca.R11_Paris {
-		chainConfig.MergeNetsplitBlock = big.NewInt(0).SetUint64(parisBlock)
+		chainConfig.MergeNetsplitBlock = big.NewInt(0)
 	}
 	if targetRevision >= tosca.R12_Shanghai {
-		chainConfig.ShanghaiTime = &shanghaiTime
+		chainConfig.ShanghaiTime = &zeroTime
 	}
 	if targetRevision >= tosca.R13_Cancun {
-		chainConfig.CancunTime = &cancunTime
+		chainConfig.CancunTime = &zeroTime
 	}
 	if targetRevision >= tosca.R14_Prague {
-		chainConfig.PragueTime = &pragueTime
+		chainConfig.PragueTime = &zeroTime
 	}
 
 	return chainConfig

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -101,16 +101,15 @@ func (m *gethVm) Run(parameters tosca.Parameters) (tosca.Result, error) {
 // chainId needs to be prefilled as it may be accessed with the opcode CHAINID.
 // the fork-blocks and the fork-times are set to the respective values for the given revision.
 func MakeChainConfig(baseline params.ChainConfig, chainId *big.Int, targetRevision tosca.Revision) params.ChainConfig {
-	maxUintBlock := big.NewInt(0).SetUint64(^uint64(0))
 	zeroTime := uint64(0)
 
 	chainConfig := baseline
 	chainConfig.ChainID = chainId
 	chainConfig.ByzantiumBlock = big.NewInt(0)
 	chainConfig.IstanbulBlock = big.NewInt(0)
-	chainConfig.BerlinBlock = maxUintBlock
-	chainConfig.LondonBlock = maxUintBlock
-	chainConfig.MergeNetsplitBlock = maxUintBlock
+	chainConfig.BerlinBlock = nil
+	chainConfig.LondonBlock = nil
+	chainConfig.MergeNetsplitBlock = nil
 
 	if targetRevision >= tosca.R09_Berlin {
 		chainConfig.BerlinBlock = big.NewInt(0)

--- a/go/interpreter/geth/geth_test.go
+++ b/go/interpreter/geth/geth_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/tosca/go/tosca"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func TestGethInterpreter_MakeChainConfigSetsTheCorrectRevision(t *testing.T) {
+	revisions := []tosca.Revision{
+		tosca.R07_Istanbul,
+		tosca.R09_Berlin,
+		tosca.R10_London,
+		tosca.R11_Paris,
+		tosca.R12_Shanghai,
+		tosca.R13_Cancun,
+		tosca.R14_Prague,
+	}
+
+	for _, targetRevision := range revisions {
+		t.Run(targetRevision.String(), func(t *testing.T) {
+			chainConfig := MakeChainConfig(
+				*params.AllEthashProtocolChanges,
+				big.NewInt(0),
+				targetRevision,
+			)
+
+			revisionChecksPreParis := map[tosca.Revision]func(blockNumber *big.Int) bool{
+				tosca.R07_Istanbul: chainConfig.IsIstanbul,
+				tosca.R09_Berlin:   chainConfig.IsBerlin,
+				tosca.R10_London:   chainConfig.IsLondon,
+			}
+			revisionChecksPostParis := map[tosca.Revision]func(blockNumber *big.Int, blockTime uint64) bool{
+				tosca.R12_Shanghai: chainConfig.IsShanghai,
+				tosca.R13_Cancun:   chainConfig.IsCancun,
+				tosca.R14_Prague:   chainConfig.IsPrague,
+			}
+
+			blockNumber := big.NewInt(0)
+			blockTime := uint64(0)
+
+			for revision, check := range revisionChecksPreParis {
+				if revision <= targetRevision && !check(blockNumber) {
+					t.Errorf("%s is before %s and should be supported", revision, targetRevision)
+				}
+				if revision > targetRevision && check(blockNumber) {
+					t.Errorf("%s is after %s and should not be supported", revision, targetRevision)
+				}
+			}
+			for revision, check := range revisionChecksPostParis {
+				if revision <= targetRevision && !check(blockNumber, blockTime) {
+					t.Errorf("%s is before %s and should be supported", revision, targetRevision)
+				}
+				if revision > targetRevision && check(blockNumber, blockTime) {
+					t.Errorf("%s is after %s and should not be supported", revision, targetRevision)
+				}
+			}
+		})
+	}
+
+}

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -238,9 +238,10 @@ func transactionToMessage(transaction tosca.Transaction, gasPrice tosca.Value, b
 				ChainID: *uint256.NewInt(0).SetBytes(authorization.ChainID[:]),
 				Address: common.Address(authorization.Address),
 				Nonce:   authorization.Nonce,
-				V:       authorization.V,
-				R:       *uint256.NewInt(0).SetBytes(authorization.R[:]),
-				S:       *uint256.NewInt(0).SetBytes(authorization.S[:]),
+
+				V: authorization.V,                                 //nolint:all
+				R: *uint256.NewInt(0).SetBytes(authorization.R[:]), //nolint:all
+				S: *uint256.NewInt(0).SetBytes(authorization.S[:]), //nolint:all
 			}
 		}
 	}

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -239,6 +239,7 @@ func transactionToMessage(transaction tosca.Transaction, gasPrice tosca.Value, b
 				Address: common.Address(authorization.Address),
 				Nonce:   authorization.Nonce,
 
+				// Ignore linting due to the deprecation of the V, R, S fields.
 				V: authorization.V,                                 //nolint:all
 				R: *uint256.NewInt(0).SetBytes(authorization.R[:]), //nolint:all
 				S: *uint256.NewInt(0).SetBytes(authorization.S[:]), //nolint:all

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -239,10 +239,9 @@ func transactionToMessage(transaction tosca.Transaction, gasPrice tosca.Value, b
 				Address: common.Address(authorization.Address),
 				Nonce:   authorization.Nonce,
 
-				// Ignore linting due to the deprecation of the V, R, S fields.
-				V: authorization.V,                                 //nolint:all
-				R: *uint256.NewInt(0).SetBytes(authorization.R[:]), //nolint:all
-				S: *uint256.NewInt(0).SetBytes(authorization.S[:]), //nolint:all
+				V: authorization.V,
+				R: *uint256.NewInt(0).SetBytes(authorization.R[:]),
+				S: *uint256.NewInt(0).SetBytes(authorization.S[:]),
 			}
 		}
 	}

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -230,18 +230,34 @@ func transactionToMessage(transaction tosca.Transaction, gasPrice tosca.Value, b
 		})
 	}
 
+	var authorizations []types.SetCodeAuthorization
+	if transaction.AuthorizationList != nil {
+		authorizations = make([]types.SetCodeAuthorization, len(transaction.AuthorizationList))
+		for idx, authorization := range transaction.AuthorizationList {
+			authorizations[idx] = types.SetCodeAuthorization{
+				ChainID: *uint256.NewInt(0).SetBytes(authorization.ChainID[:]),
+				Address: common.Address(authorization.Address),
+				Nonce:   authorization.Nonce,
+				V:       authorization.V,
+				R:       *uint256.NewInt(0).SetBytes(authorization.R[:]),
+				S:       *uint256.NewInt(0).SetBytes(authorization.S[:]),
+			}
+		}
+	}
+
 	return &core.Message{
-		From:          common.Address(transaction.Sender),
-		To:            (*common.Address)(transaction.Recipient),
-		Nonce:         transaction.Nonce,
-		Value:         transaction.Value.ToBig(),
-		GasLimit:      uint64(transaction.GasLimit),
-		GasPrice:      gasPrice.ToBig(),
-		GasFeeCap:     transaction.GasFeeCap.ToBig(),
-		GasTipCap:     transaction.GasTipCap.ToBig(),
-		Data:          transaction.Input,
-		AccessList:    accessList,
-		BlobGasFeeCap: transaction.BlobGasFeeCap.ToBig(),
-		BlobHashes:    blobHashes,
+		From:                  common.Address(transaction.Sender),
+		To:                    (*common.Address)(transaction.Recipient),
+		Nonce:                 transaction.Nonce,
+		Value:                 transaction.Value.ToBig(),
+		GasLimit:              uint64(transaction.GasLimit),
+		GasPrice:              gasPrice.ToBig(),
+		GasFeeCap:             transaction.GasFeeCap.ToBig(),
+		GasTipCap:             transaction.GasTipCap.ToBig(),
+		Data:                  transaction.Input,
+		AccessList:            accessList,
+		BlobGasFeeCap:         transaction.BlobGasFeeCap.ToBig(),
+		BlobHashes:            blobHashes,
+		SetCodeAuthorizations: authorizations,
 	}
 }

--- a/go/processor/geth/processor_test.go
+++ b/go/processor/geth/processor_test.go
@@ -110,7 +110,7 @@ func TestTransactionToMessage_BasicFields(t *testing.T) {
 		Input:         []byte{0x42, 0x42},
 		BlobGasFeeCap: tosca.NewValue(0),
 	}
-	gasPrice := tosca.NewValue(50)
+	gasPrice := tosca.NewValue(40)
 	blobHashes := []common.Hash{{0xaa}}
 	msg := transactionToMessage(tx, gasPrice, blobHashes)
 
@@ -207,7 +207,7 @@ func TestTransactionToMessage_AuthorizationList(t *testing.T) {
 	if auth.Nonce != tx.AuthorizationList[0].Nonce {
 		t.Errorf("Nonce mismatch")
 	}
-	if auth.V != tx.AuthorizationList[0].V { //nolint:all
+	if auth.V != tx.AuthorizationList[0].V {
 		t.Errorf("V mismatch")
 	}
 	if auth.R.Cmp(uint256.NewInt(3)) != 0 {

--- a/go/processor/geth/processor_test.go
+++ b/go/processor/geth/processor_test.go
@@ -207,7 +207,7 @@ func TestTransactionToMessage_AuthorizationList(t *testing.T) {
 	if auth.Nonce != tx.AuthorizationList[0].Nonce {
 		t.Errorf("Nonce mismatch")
 	}
-	if auth.V != tx.AuthorizationList[0].V {
+	if auth.V != tx.AuthorizationList[0].V { //nolint:all
 		t.Errorf("V mismatch")
 	}
 	if auth.R.Cmp(uint256.NewInt(3)) != 0 {

--- a/go/processor/geth/processor_test.go
+++ b/go/processor/geth/processor_test.go
@@ -11,10 +11,13 @@
 package geth_processor
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
 	"github.com/0xsoniclabs/tosca/go/tosca"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
 	"go.uber.org/mock/gomock"
 )
 
@@ -92,5 +95,125 @@ func TestGethProcessor_ConfigAddsStateContract(t *testing.T) {
 	_, ok := config.StatePrecompiles[stateContractAddress]
 	if !ok {
 		t.Errorf("state contract not added to config")
+	}
+}
+
+func TestTransactionToMessage_BasicFields(t *testing.T) {
+	tx := tosca.Transaction{
+		Sender:        tosca.Address{0x01},
+		Recipient:     &tosca.Address{0x02},
+		Nonce:         42,
+		Value:         tosca.NewValue(1000),
+		GasLimit:      21000,
+		GasFeeCap:     tosca.NewValue(50),
+		GasTipCap:     tosca.NewValue(2),
+		Input:         []byte{0x42, 0x42},
+		BlobGasFeeCap: tosca.NewValue(0),
+	}
+	gasPrice := tosca.NewValue(50)
+	blobHashes := []common.Hash{{0xaa}}
+	msg := transactionToMessage(tx, gasPrice, blobHashes)
+
+	if msg.From != common.Address(tx.Sender) {
+		t.Errorf("From mismatch: got %x, want %x", msg.From, tx.Sender)
+	}
+	if msg.To == nil || *msg.To != common.Address(*tx.Recipient) {
+		t.Errorf("To mismatch: got %v, want %v", msg.To, tx.Recipient)
+	}
+	if msg.Nonce != tx.Nonce {
+		t.Errorf("Nonce mismatch: got %d, want %d", msg.Nonce, tx.Nonce)
+	}
+	if msg.Value.Cmp(tx.Value.ToBig()) != 0 {
+		t.Errorf("Value mismatch: got %v, want %v", msg.Value, tx.Value.ToBig())
+	}
+	if msg.GasLimit != uint64(tx.GasLimit) {
+		t.Errorf("GasLimit mismatch: got %d, want %d", msg.GasLimit, tx.GasLimit)
+	}
+	if msg.GasPrice.Cmp(gasPrice.ToBig()) != 0 {
+		t.Errorf("GasPrice mismatch: got %v, want %v", msg.GasPrice, gasPrice.ToBig())
+	}
+	if msg.GasFeeCap.Cmp(tx.GasFeeCap.ToBig()) != 0 {
+		t.Errorf("GasFeeCap mismatch: got %v, want %v", msg.GasFeeCap, tx.GasFeeCap.ToBig())
+	}
+	if msg.GasTipCap.Cmp(tx.GasTipCap.ToBig()) != 0 {
+		t.Errorf("GasTipCap mismatch: got %v, want %v", msg.GasTipCap, tx.GasTipCap.ToBig())
+	}
+	if !bytes.Equal(msg.Data, tx.Input) {
+		t.Errorf("Input mismatch: got %x, want %x", msg.Data, tx.Input)
+	}
+	if msg.BlobGasFeeCap.Cmp(tx.BlobGasFeeCap.ToBig()) != 0 {
+		t.Errorf("BlobGasFeeCap mismatch: got %v, want %v", msg.BlobGasFeeCap, tx.BlobGasFeeCap.ToBig())
+	}
+	if len(msg.BlobHashes) != 1 || msg.BlobHashes[0] != blobHashes[0] {
+		t.Errorf("BlobHashes mismatch: got %v, want %v", msg.BlobHashes, blobHashes)
+	}
+}
+
+func TestTransactionToMessage_AccessList(t *testing.T) {
+	tx := tosca.Transaction{
+		Sender: tosca.Address{0x01},
+		AccessList: []tosca.AccessTuple{
+			{
+				Address: tosca.Address{0x03},
+				Keys:    []tosca.Key{{0x42}, {0x43}},
+			},
+		},
+	}
+	gasPrice := tosca.NewValue(1)
+	msg := transactionToMessage(tx, gasPrice, nil)
+	if len(msg.AccessList) != 1 {
+		t.Fatalf("expected 1 access tuple, got %d", len(msg.AccessList))
+	}
+	if msg.AccessList[0].Address != common.Address(tx.AccessList[0].Address) {
+		t.Errorf("AccessList address mismatch")
+	}
+	if len(msg.AccessList[0].StorageKeys) != 2 {
+		t.Errorf("expected 2 storage keys, got %d", len(msg.AccessList[0].StorageKeys))
+	}
+	if msg.AccessList[0].StorageKeys[0] != common.Hash(tx.AccessList[0].Keys[0]) {
+		t.Errorf("StorageKey[0] mismatch")
+	}
+	if msg.AccessList[0].StorageKeys[1] != common.Hash(tx.AccessList[0].Keys[1]) {
+		t.Errorf("StorageKey[1] mismatch")
+	}
+}
+
+func TestTransactionToMessage_AuthorizationList(t *testing.T) {
+	tx := tosca.Transaction{
+		Sender: [20]byte{0x01},
+		AuthorizationList: []tosca.SetCodeAuthorization{
+			{
+				ChainID: tosca.Word(tosca.NewValue(0x01)),
+				Address: tosca.Address{0x02},
+				Nonce:   7,
+				V:       42,
+				R:       tosca.Word(tosca.NewValue(0x03)),
+				S:       tosca.Word(tosca.NewValue(0x04)),
+			},
+		},
+	}
+	gasPrice := tosca.NewValue(1)
+	msg := transactionToMessage(tx, gasPrice, nil)
+	if len(msg.SetCodeAuthorizations) != 1 {
+		t.Fatalf("expected 1 authorization, got %d", len(msg.SetCodeAuthorizations))
+	}
+	auth := msg.SetCodeAuthorizations[0]
+	if auth.ChainID.Cmp(uint256.NewInt(1)) != 0 {
+		t.Errorf("ChainID mismatch: got %v", auth.ChainID)
+	}
+	if auth.Address != common.Address(tx.AuthorizationList[0].Address) {
+		t.Errorf("Address mismatch")
+	}
+	if auth.Nonce != tx.AuthorizationList[0].Nonce {
+		t.Errorf("Nonce mismatch")
+	}
+	if auth.V != tx.AuthorizationList[0].V {
+		t.Errorf("V mismatch")
+	}
+	if auth.R.Cmp(uint256.NewInt(3)) != 0 {
+		t.Errorf("R mismatch: got %v", auth.R)
+	}
+	if auth.S.Cmp(uint256.NewInt(4)) != 0 {
+		t.Errorf("S mismatch: got %v", auth.S)
 	}
 }

--- a/go/tosca/processor.go
+++ b/go/tosca/processor.go
@@ -38,13 +38,19 @@ type Transaction struct {
 	AuthorizationList []SetCodeAuthorization
 }
 
+// SetCodeAuthorization contains the information required for EIP-7702 set code transactions to
+// enable externally owned accounts (EOAs) to reference code and execute within their own context.
 type SetCodeAuthorization struct {
-	ChainID Word
-	Address Address
-	Nonce   uint64
-	V       uint8
-	R       Word
-	S       Word
+	ChainID Word    // the chain ID for which this authorization is valid
+	Address Address // the target address of the delegation
+	Nonce   uint64  // the nonce of the signer, used to prevent replay
+
+	// Deprecated: signature V value required by the geth processor.
+	V uint8
+	// Deprecated: signature R value required by the geth processor.
+	R Word
+	// Deprecated: signature S value required by the geth processor.
+	S Word
 }
 
 // AccessTuple lists a range of accounts and storage slots expected to be accessed

--- a/go/tosca/processor.go
+++ b/go/tosca/processor.go
@@ -44,13 +44,9 @@ type SetCodeAuthorization struct {
 	ChainID Word    // the chain ID for which this authorization is valid
 	Address Address // the target address of the delegation
 	Nonce   uint64  // the nonce of the signer, used to prevent replay
-
-	// Deprecated: signature V value required by the geth processor.
-	V uint8
-	// Deprecated: signature R value required by the geth processor.
-	R Word
-	// Deprecated: signature S value required by the geth processor.
-	S Word
+	V       uint8   // the recovery id of the signature
+	R       Word    // the first value of the signature
+	S       Word    // the second value of the signature
 }
 
 // AccessTuple lists a range of accounts and storage slots expected to be accessed

--- a/go/tosca/processor.go
+++ b/go/tosca/processor.go
@@ -24,18 +24,27 @@ type Processor interface {
 
 // Transaction summarizes the parameters of a transaction to be executed on a chain.
 type Transaction struct {
-	Sender        Address       // the sender of the transaction, paying for its execution
-	Recipient     *Address      // the receiver of a transaction, nil if a new contract is to be created
-	Nonce         uint64        // the nonce of the sender account, used to prevent replay attacks
-	Input         Data          // the input data for the transaction
-	Value         Value         // the amount of network currency to transfer to the recipient
-	GasLimit      Gas           // the maximum amount of gas that can be used by the transaction
-	GasFeeCap     Value         // the amount of network currency the sender is willing to pay for one gas unit
-	GasTipCap     Value         // the amount of network currency the sender is willing to pay for one unit as a priority fee
-	BlobGasFeeCap Value         // the amount of network currency the sender is willing to pay for blob gas
-	BlobHashes    []Hash        // the hashes of the blobs for this transaction
-	AccessList    []AccessTuple // the list of accounts and storage slots expected to be accessed
+	Sender            Address       // the sender of the transaction, paying for its execution
+	Recipient         *Address      // the receiver of a transaction, nil if a new contract is to be created
+	Nonce             uint64        // the nonce of the sender account, used to prevent replay attacks
+	Input             Data          // the input data for the transaction
+	Value             Value         // the amount of network currency to transfer to the recipient
+	GasLimit          Gas           // the maximum amount of gas that can be used by the transaction
+	GasFeeCap         Value         // the amount of network currency the sender is willing to pay for one gas unit
+	GasTipCap         Value         // the amount of network currency the sender is willing to pay for one unit as a priority fee
+	BlobGasFeeCap     Value         // the amount of network currency the sender is willing to pay for blob gas
+	BlobHashes        []Hash        // the hashes of the blobs for this transaction
+	AccessList        []AccessTuple // the list of accounts and storage slots expected to be accessed
+	AuthorizationList []SetCodeAuthorization
+}
 
+type SetCodeAuthorization struct {
+	ChainID Word
+	Address Address
+	Nonce   uint64
+	V       uint8
+	R       Word
+	S       Word
 }
 
 // AccessTuple lists a range of accounts and storage slots expected to be accessed


### PR DESCRIPTION
This PR adds Prague support to the processor types and geth reference implementation by adding `SetCodeAuthorizations` and refactoring the `MakeChainConfig` function.