### PR TITLE
Remove strict project coverage threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,9 +17,6 @@ coverage:
       default:
         target: 80% # coverage of the changes
         threshold: 1% # allow the coverage to drop by <threshold>%
-    project:
-      default:
-        target: 80% # coverage of the project
 ignore:
   - "**/*_mock.go"
   - "**/*_test.go"


### PR DESCRIPTION
This PR removes strict project coverage target. Project coverage meansures coverage level of the entire repository. Previously, project coverage has not been activated. With the recent codecov plan change, project coverage takes effects. This condition may unnecessary prevent PR from merging.