### PR TITLE
Processor: Ignore gas used in case of error

### DIFF
--- a/go/integration_test/processor/processor_gas_test.go
+++ b/go/integration_test/processor/processor_gas_test.go
@@ -344,7 +344,7 @@ func exactSufficientAndInsufficientScenarios(exactScenario Scenario, name string
 	insufficient := exactScenario.Clone()
 	insufficient.Transaction.GasLimit -= 1
 	insufficient.Receipt.Success = false
-	insufficient.Receipt.GasUsed = insufficient.Transaction.GasLimit
+	insufficient.Receipt.GasUsed = 0
 	insufficient.OperaError = fmt.Errorf("gas too low")
 	// Reset world state in case of failure
 	beforeSender := insufficient.Before[insufficient.Transaction.Sender]

--- a/go/processor/floria/processor.go
+++ b/go/processor/floria/processor.go
@@ -92,7 +92,7 @@ func (p *Processor) Run(
 
 	setupGas := calculateSetupGas(transaction, blockParameters.Revision)
 	if transaction.GasLimit < setupGas {
-		return tosca.Receipt{GasUsed: transaction.GasLimit}, fmt.Errorf("insufficient gas for set up: %w", err)
+		return tosca.Receipt{}, fmt.Errorf("insufficient gas for set up: %w", err)
 	}
 
 	buyGas(transaction, gasPrice, blockParameters.BlobBaseFee, context)

--- a/go/processor/geth/processor.go
+++ b/go/processor/geth/processor.go
@@ -11,7 +11,6 @@
 package geth_processor
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -83,10 +82,7 @@ func (p *Processor) Run(
 	result, err := core.ApplyMessage(evm, msg, gasPool)
 	if err != nil {
 		context.RestoreSnapshot(snapshot)
-		if !p.EthereumCompatible && errors.Is(err, core.ErrInsufficientFunds) {
-			return tosca.Receipt{}, err
-		}
-		return tosca.Receipt{GasUsed: transaction.GasLimit}, err
+		return tosca.Receipt{}, err
 	}
 
 	createdAddress := (*tosca.Address)(stateDB.GetCreatedContract())

--- a/go/processor/opera/processor.go
+++ b/go/processor/opera/processor.go
@@ -191,7 +191,7 @@ func (p *processor) Run(
 		return tosca.Receipt{}, err
 	}
 	if gas < intrinsicGasCosts {
-		return tosca.Receipt{GasUsed: transaction.GasLimit}, fmt.Errorf("%w: have %d, want %d", errIntrinsicGas, transaction.GasLimit, intrinsicGasCosts)
+		return tosca.Receipt{}, fmt.Errorf("%w: have %d, want %d", errIntrinsicGas, transaction.GasLimit, intrinsicGasCosts)
 	}
 	gas -= intrinsicGasCosts
 

--- a/go/processor/opera/processor_test.go
+++ b/go/processor/opera/processor_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/tosca/go/tosca"
+	"go.uber.org/mock/gomock"
+)
+
+func TestProcessor_ReceiptIsDefaultInitializedInCaseOfError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	context := tosca.NewMockTransactionContext(ctrl)
+	context.EXPECT().GetNonce(gomock.Any())
+	context.EXPECT().GetCodeHash(gomock.Any())
+	context.EXPECT().GetBalance(gomock.Any())
+	context.EXPECT().SetBalance(gomock.Any(), gomock.Any())
+
+	interpreter := tosca.NewMockInterpreter(ctrl)
+	processor := newProcessor(interpreter)
+	blockParams := tosca.BlockParameters{}
+	transaction := tosca.Transaction{}
+	receipt, err := processor.Run(blockParams, transaction, context)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+	if receipt.Success || receipt.GasUsed != 0 || receipt.BlobGasUsed != 0 ||
+		receipt.Output != nil || receipt.ContractAddress != nil || len(receipt.Logs) != 0 {
+		t.Errorf("expected empty receipt, got %v", receipt)
+	}
+}


### PR DESCRIPTION
In case of an error, the receipt should be ignored and therefore also the gas used. The geth reference implementation and floria were checked against the ethereum tests and execution spec tests to ensure geth does not require a specific gas value in the case of an error.