### PR TITLE
Update geth dependency to 1.16.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,9 +41,10 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/emicklei/dot v1.6.2 // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.0 // indirect
 	github.com/ethereum/go-verkle v0.2.2 // indirect
-	github.com/ferranbt/fastssz v0.1.2 // indirect
+	github.com/ferranbt/fastssz v0.1.4 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
@@ -67,6 +68,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20250627083633-bbe492095a30
+replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20250827114033-a49cee8740d2
 
 replace github.com/ethereum/evmc/v11 => ./third_party/evmc

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/go-ethereum v0.0.0-20250627083633-bbe492095a30 h1:3vpMpd29elfFfiaDG01WDRPpxX1P8I6jNuxQUkdDRn8=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20250627083633-bbe492095a30/go.mod h1:yBASzR5thK8ugXyLfz9doxUsDJrkAfDOePc5upeFvvg=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20250827114033-a49cee8740d2 h1:OHaJBUO/R6SOHCDNMskfnakEz59bo1fl7Tmz73GCUnA=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20250827114033-a49cee8740d2/go.mod h1:pm9P/VM1zE+1AQPGpoCEaA/0sbu7GFNex/nyjjPRcrU=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
@@ -46,12 +46,14 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/dsnet/golib/unitconv v1.0.2 h1:45gXng3Op1vTrnX1PdM9Bla4mEpBFYA5aC8dlqacmwM=
 github.com/dsnet/golib/unitconv v1.0.2/go.mod h1:86KTUtTJFLreKjc4sS9xE0rhj4lR44Ox0rEQSEXSWwM=
+github.com/emicklei/dot v1.6.2 h1:08GN+DD79cy/tzN6uLCT84+2Wk9u+wvqP+Hkx/dIR8A=
+github.com/emicklei/dot v1.6.2/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
-github.com/ferranbt/fastssz v0.1.2 h1:Dky6dXlngF6Qjc+EfDipAkE83N5I5DE68bY6O0VLNPk=
-github.com/ferranbt/fastssz v0.1.2/go.mod h1:X5UPrE2u1UJjxHA8X54u04SBwdAQjG2sFtWs39YxyWs=
+github.com/ferranbt/fastssz v0.1.4 h1:OCDB+dYDEQDvAgtAGnTSidK1Pe2tW3nFV40XyMkTeDY=
+github.com/ferranbt/fastssz v0.1.4/go.mod h1:Ea3+oeoRGGLGm5shYAeDgu6PGUlcvQhE2fILyD9+tGg=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
@@ -113,8 +115,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
-github.com/prysmaticlabs/gohashtree v0.0.1-alpha.0.20220714111606-acbb2962fb48 h1:cSo6/vk8YpvkLbk9v3FO97cakNmUoxwi2KMP8hd5WIw=
-github.com/prysmaticlabs/gohashtree v0.0.1-alpha.0.20220714111606-acbb2962fb48/go.mod h1:4pWaT30XoEx1j8KNJf3TV+E3mQkaufn7mf+jRNb/Fuk=
+github.com/prysmaticlabs/gohashtree v0.0.4-beta h1:H/EbCuXPeTV3lpKeXGPpEV9gsUpkqOOVnWapUyeWro4=
+github.com/prysmaticlabs/gohashtree v0.0.4-beta/go.mod h1:BFdtALS+Ffhg3lGQIHv9HDWuHS8cTvHZzrHWxwOtGOs=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -411,13 +411,12 @@ func (a *runContextAdapter) GetStorage(addr tosca.Address, key tosca.Key) tosca.
 }
 
 func (a *runContextAdapter) SetStorage(addr tosca.Address, key tosca.Key, future tosca.Word) tosca.StorageStatus {
-	current := a.GetStorage(addr, key)
-	if current == future {
+	current, original := a.evm.StateDB.GetStateAndCommittedState(common.Address(addr), common.Hash(key))
+	if tosca.Word(current) == future {
 		return tosca.StorageAssigned
 	}
-	original := tosca.Word(a.evm.StateDB.GetCommittedState(common.Address(addr), common.Hash(key)))
 	a.evm.StateDB.SetState(common.Address(addr), common.Hash(key), common.Hash(future))
-	return tosca.GetStorageStatus(original, current, future)
+	return tosca.GetStorageStatus(tosca.Word(original), tosca.Word(current), future)
 }
 
 func (a *runContextAdapter) GetTransientStorage(addr tosca.Address, key tosca.Key) tosca.Word {
@@ -536,7 +535,8 @@ func (a *runContextAdapter) AccessStorage(addr tosca.Address, key tosca.Key) tos
 // -- legacy API needed by LFVM and Geth, to be removed in the future ---
 
 func (a *runContextAdapter) GetCommittedStorage(addr tosca.Address, key tosca.Key) tosca.Word {
-	return tosca.Word(a.evm.StateDB.GetCommittedState(common.Address(addr), common.Hash(key)))
+	_, committed := a.evm.StateDB.GetStateAndCommittedState(common.Address(addr), common.Hash(key))
+	return tosca.Word(committed)
 }
 
 func (a *runContextAdapter) IsAddressInAccessList(addr tosca.Address) bool {

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -168,9 +168,8 @@ func TestRunContextAdapter_SetAndGetStorage(t *testing.T) {
 			key := tosca.Key{10}
 			original := tosca.Word{1}
 
-			stateDb.EXPECT().GetState(common.Address(address), common.Hash(key)).Return(common.Hash(test.current))
+			stateDb.EXPECT().GetStateAndCommittedState(common.Address(address), common.Hash(key)).Return(common.Hash(original), common.Hash(test.current))
 			if test.current != test.future {
-				stateDb.EXPECT().GetCommittedState(common.Address(address), common.Hash(key)).Return(common.Hash(original))
 				stateDb.EXPECT().SetState(common.Address(address), common.Hash(key), common.Hash(test.future))
 			}
 
@@ -368,7 +367,7 @@ func TestRunContextAdapter_GettersReturnTheCorrectStateDbValues(t *testing.T) {
 		},
 		"committedState": {
 			primingMock: func(stateDb *MockStateDb) {
-				stateDb.EXPECT().GetCommittedState(common.Address{0x42}, common.Hash{0x10}).Return(common.Hash{2})
+				stateDb.EXPECT().GetStateAndCommittedState(common.Address{0x42}, common.Hash{0x10}).Return(common.Hash{4}, common.Hash{2})
 			},
 			want: tosca.Word{2},
 			functionCall: func(adapter *runContextAdapter) any {
@@ -454,8 +453,7 @@ func TestRunContextAdapter_SettersForwardTheCorrectStateDbValues(t *testing.T) {
 		},
 		"storage": {
 			primingMock: func(stateDb *MockStateDb) {
-				stateDb.EXPECT().GetState(common.Address{0x42}, common.Hash{0x10}).Return(common.Hash{0x01})
-				stateDb.EXPECT().GetCommittedState(common.Address{0x42}, common.Hash{0x10}).Return(common.Hash{0x02})
+				stateDb.EXPECT().GetStateAndCommittedState(common.Address{0x42}, common.Hash{0x10}).Return(common.Hash{0x01}, common.Hash{0x02})
 				stateDb.EXPECT().SetState(common.Address{0x42}, common.Hash{0x10}, common.Hash{0x03})
 			},
 			functionCall: func(adapter *runContextAdapter) {

--- a/go/geth_adapter/adapter_test_mocks.go
+++ b/go/geth_adapter/adapter_test_mocks.go
@@ -402,20 +402,6 @@ func (mr *MockStateDbMockRecorder) GetCodeSize(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCodeSize", reflect.TypeOf((*MockStateDb)(nil).GetCodeSize), arg0)
 }
 
-// GetCommittedState mocks base method.
-func (m *MockStateDb) GetCommittedState(arg0 common.Address, arg1 common.Hash) common.Hash {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCommittedState", arg0, arg1)
-	ret0, _ := ret[0].(common.Hash)
-	return ret0
-}
-
-// GetCommittedState indicates an expected call of GetCommittedState.
-func (mr *MockStateDbMockRecorder) GetCommittedState(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommittedState", reflect.TypeOf((*MockStateDb)(nil).GetCommittedState), arg0, arg1)
-}
-
 // GetNonce mocks base method.
 func (m *MockStateDb) GetNonce(arg0 common.Address) uint64 {
 	m.ctrl.T.Helper()
@@ -456,6 +442,21 @@ func (m *MockStateDb) GetState(arg0 common.Address, arg1 common.Hash) common.Has
 func (mr *MockStateDbMockRecorder) GetState(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockStateDb)(nil).GetState), arg0, arg1)
+}
+
+// GetStateAndCommittedState mocks base method.
+func (m *MockStateDb) GetStateAndCommittedState(arg0 common.Address, arg1 common.Hash) (common.Hash, common.Hash) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStateAndCommittedState", arg0, arg1)
+	ret0, _ := ret[0].(common.Hash)
+	ret1, _ := ret[1].(common.Hash)
+	return ret0, ret1
+}
+
+// GetStateAndCommittedState indicates an expected call of GetStateAndCommittedState.
+func (mr *MockStateDbMockRecorder) GetStateAndCommittedState(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateAndCommittedState", reflect.TypeOf((*MockStateDb)(nil).GetStateAndCommittedState), arg0, arg1)
 }
 
 // GetStorageRoot mocks base method.

--- a/go/geth_adapter/state_db.go
+++ b/go/geth_adapter/state_db.go
@@ -42,6 +42,12 @@ func NewStateDB(ctx tosca.TransactionContext) *StateDB {
 	return &StateDB{context: ctx}
 }
 
+func (s *StateDB) GetStateAndCommittedState(address common.Address, key common.Hash) (common.Hash, common.Hash) {
+	state := common.Hash(s.context.GetStorage(tosca.Address(address), tosca.Key(key)))
+	committedState := common.Hash(s.context.GetCommittedStorage(tosca.Address(address), tosca.Key(key)))
+	return state, committedState
+}
+
 func (s *StateDB) GetCreatedContract() *common.Address {
 	return s.createdContract
 }
@@ -137,11 +143,6 @@ func (s *StateDB) SubRefund(refund uint64) {
 
 func (s *StateDB) GetRefund() uint64 {
 	return s.refund
-}
-
-// GetCommittedState should only be used by geth_adapter
-func (s *StateDB) GetCommittedState(address common.Address, key common.Hash) common.Hash {
-	return common.Hash(s.context.GetCommittedStorage(tosca.Address(address), tosca.Key(key)))
 }
 
 func (s *StateDB) GetState(address common.Address, key common.Hash) common.Hash {

--- a/go/geth_adapter/state_db_test.go
+++ b/go/geth_adapter/state_db_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/tosca/go/tosca"
+	common "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -72,4 +73,22 @@ func TestStateDB_RevertToSnapshot_InvalidSnapshot_IsIgnored(t *testing.T) {
 			db.RevertToSnapshot(snapshot)
 		})
 	}
+}
+
+func TestStateDB_GetStateAndCommittedStateReturnsOriginalAndCurrentState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	context := tosca.NewMockTransactionContext(ctrl)
+
+	address := tosca.Address{0x1}
+	key := tosca.Key{0x2}
+	original := tosca.Word{0x3}
+	current := tosca.Word{0x4}
+
+	context.EXPECT().GetStorage(address, key).Return(original)
+	context.EXPECT().GetCommittedStorage(address, key).Return(current)
+	stateDB := NewStateDB(context)
+
+	state, committed := stateDB.GetStateAndCommittedState(common.Address(address), common.Hash(key))
+	require.Equal(t, original, tosca.Word(state))
+	require.Equal(t, current, tosca.Word(committed))
 }

--- a/go/integration_test/interpreter/integration_test.go
+++ b/go/integration_test/interpreter/integration_test.go
@@ -1075,6 +1075,7 @@ func getRadomByte32() []byte {
 
 func setDefaultCallStateDBMock(mockStateDB *MockStateDB, account tosca.Address, code []byte) {
 	// mock state calls for call instruction
+	mockStateDB.EXPECT().GetCommittedStorage(gomock.Any(), gomock.Any()).AnyTimes().Return(tosca.Word{1})
 	mockStateDB.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(tosca.Value{1})
 	mockStateDB.EXPECT().GetNonce(gomock.Any()).AnyTimes().Return(uint64(123))
 	mockStateDB.EXPECT().SetNonce(gomock.Any(), gomock.Any()).AnyTimes()


### PR DESCRIPTION
With the upcoming Fusaka update of ethereum, the geth dependency needs to be updated to enable Oasaka features.