### PR TITLE
Fix handling of snapshots of refund states in state DB adapter

### DIFF
--- a/go/geth_adapter/state_db_test.go
+++ b/go/geth_adapter/state_db_test.go
@@ -13,9 +13,63 @@ package geth_adapter
 import (
 	"testing"
 
+	"github.com/0xsoniclabs/tosca/go/tosca"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestStateDB_implementsVmStateDBInterface(t *testing.T) {
 	var _ vm.StateDB = &StateDB{}
+}
+
+func TestStateDB_RefundSnapshots_RecoversProperRefund(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	context := tosca.NewMockTransactionContext(ctrl)
+
+	context.EXPECT().CreateSnapshot().Return(tosca.Snapshot(12)).AnyTimes()
+	context.EXPECT().RestoreSnapshot(tosca.Snapshot(12)).AnyTimes()
+
+	db := StateDB{context: context}
+
+	require.Equal(uint64(0), db.GetRefund())
+	s1 := db.Snapshot()
+
+	db.AddRefund(10)
+	require.Equal(uint64(10), db.GetRefund())
+	s2 := db.Snapshot()
+
+	db.SubRefund(3)
+	require.Equal(uint64(7), db.GetRefund())
+	s3 := db.Snapshot()
+
+	db.AddRefund(5)
+	require.Equal(uint64(12), db.GetRefund())
+
+	db.RevertToSnapshot(s3)
+	require.Equal(uint64(7), db.GetRefund())
+
+	db.RevertToSnapshot(s2)
+	require.Equal(uint64(10), db.GetRefund())
+
+	db.RevertToSnapshot(s1)
+	require.Equal(uint64(0), db.GetRefund())
+}
+
+func TestStateDB_RevertToSnapshot_InvalidSnapshot_IsIgnored(t *testing.T) {
+	tests := map[string]int{
+		"negative": -1,
+		"invalid":  0,
+	}
+
+	for name, snapshot := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			context := tosca.NewMockTransactionContext(ctrl)
+
+			db := StateDB{context: context}
+			db.RevertToSnapshot(snapshot)
+		})
+	}
 }


### PR DESCRIPTION
This PR fixes the creation and restoration of snapshots in the `geth_adaptor`'s StateDB as it is used by Tosca's geth reference processor implementation.

Before this fix, the implementation depended on the underlying system to produce distinct snapshot IDs for each call. However, this is not the case for some implementations, in particular the `Carmen` DB, which may reuse IDs.

With this fix, this problem got resolved.