### PR TITLE
Fix CI setup for tests with memory sanitizer

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -8,13 +8,13 @@ on:
   push:
     branches: [ main, evmrs ]
     paths:
-      - '.github/workflows/rust.yml'
+      - '.github/workflows/rust.yaml'
       - 'rust/**'
       - Makefile
   pull_request:
     branches: [ main ]
     paths:
-      - '.github/workflows/rust.yml'
+      - '.github/workflows/rust.yaml'
       - 'rust/**'
       - Makefile
 
@@ -41,8 +41,8 @@ jobs:
       working-directory: rust
       run: cargo fmt --check
 
-  clippy:
-    name: clippy
+  lint:
+    name: lint
     runs-on: ubuntu-latest
 
     steps:
@@ -132,8 +132,9 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@nightly
+      uses: dtolnay/rust-toolchain@master
       with:
+        toolchain: nightly-2025-09-10
         components: rust-src
     - name: load cache
       uses: Swatinem/rust-cache@v2
@@ -145,18 +146,20 @@ jobs:
       working-directory: rust
       env:
         RUSTFLAGS: -Zsanitizer=address
-      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache test -Zbuild-std --target x86_64-unknown-linux-gnu
+      run: cargo +nightly-2025-09-10 hack --workspace --each-feature --exclude-features needs-cache test -Zbuild-std --target x86_64-unknown-linux-gnu
     - name: cargo test with memory sanitizer
       working-directory: rust
       env:
         RUSTFLAGS: "-Zsanitizer=memory -Zsanitizer-memory-track-origins"
-      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache test -Zbuild-std --target x86_64-unknown-linux-gnu
+        RUSTDOCFLAGS: "-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cunsafe-allow-abi-mismatch=sanitizer"
+      run: cargo +nightly-2025-09-10 hack --workspace --each-feature --exclude-features needs-cache test -Zbuild-std --target x86_64-unknown-linux-gnu
     - name: cargo test with thread sanitizer
       working-directory: rust
       env:
         CFLAGS: -fsanitize=thread
         RUSTFLAGS: -Zsanitizer=thread
-      run: cargo +nightly hack --workspace --each-feature --exclude-features needs-cache test -Zbuild-std --target x86_64-unknown-linux-gnu
+        RUSTDOCFLAGS: "-Zsanitizer=thread -Cunsafe-allow-abi-mismatch=sanitizer"
+      run: cargo +nightly-2025-09-10 hack --workspace --each-feature --exclude-features needs-cache test -Zbuild-std --target x86_64-unknown-linux-gnu
 
   benchmarks-with-sanitizers:
     name: benchmarks-with-sanitizers
@@ -166,8 +169,9 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@nightly
+      uses: dtolnay/rust-toolchain@master
       with:
+        toolchain: nightly-2025-09-10
         components: rust-src
     - name: load cache
       uses: Swatinem/rust-cache@v2
@@ -179,18 +183,18 @@ jobs:
       working-directory: rust
       env:
         RUSTFLAGS: -Zsanitizer=address
-      run: cargo +nightly hack --each-feature run -Zbuild-std --target x86_64-unknown-linux-gnu --package benchmarks --release -- 1 all-short
+      run: cargo +nightly-2025-09-10 hack --each-feature run -Zbuild-std --target x86_64-unknown-linux-gnu --package benchmarks --release -- 1 all-short
     - name: cargo run benchmarks with memory sanitizer
       working-directory: rust
       env:
         RUSTFLAGS: "-Zsanitizer=memory -Zsanitizer-memory-track-origins"
-      run: cargo +nightly hack --each-feature run -Zbuild-std --target x86_64-unknown-linux-gnu --package benchmarks --release -- 1 all-short
+      run: cargo +nightly-2025-09-10 hack --each-feature run -Zbuild-std --target x86_64-unknown-linux-gnu --package benchmarks --release -- 1 all-short
     - name: cargo run benchmarks with thread sanitizer
       working-directory: rust
       env:
         CFLAGS: -fsanitize=thread
         RUSTFLAGS: -Zsanitizer=thread
-      run: cargo +nightly hack --each-feature run -Zbuild-std --target x86_64-unknown-linux-gnu --package benchmarks --release -- 1 all-short
+      run: cargo +nightly-2025-09-10 hack --each-feature run -Zbuild-std --target x86_64-unknown-linux-gnu --package benchmarks --release -- 1 all-short
 
   miri:
     name: miri
@@ -200,8 +204,9 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@nightly
+      uses: dtolnay/rust-toolchain@master
       with:
+        toolchain: nightly-2025-09-10
         components: miri
     - name: load cache
       uses: Swatinem/rust-cache@v2
@@ -213,12 +218,12 @@ jobs:
       working-directory: rust
       env: 
         MIRIFLAGS: "-Zmiri-disable-stacked-borrows -Zmiri-permissive-provenance -Zmiri-backtrace=full"
-      run: cargo +nightly hack miri test --workspace --each-feature --exclude-features needs-cache,mimalloc,performance
+      run: cargo +nightly-2025-09-10 hack miri test --workspace --each-feature --exclude-features needs-cache,mimalloc,performance
     - name: cargo miri benchmarks
       working-directory: rust
       env: 
         MIRIFLAGS: "-Zmiri-disable-stacked-borrows -Zmiri-permissive-provenance -Zmiri-backtrace=full"
-      run: cargo +nightly hack miri run --package benchmarks --each-feature --exclude-features mimalloc,performance -- 1 all-short
+      run: cargo +nightly-2025-09-10 hack miri run --package benchmarks --each-feature --exclude-features mimalloc,performance -- 1 all-short
 
   fuzz:
     name: fuzz


### PR DESCRIPTION
This PR fixes CI for running tests with sanitation.

The problem was that enabling sanitation changes the ABI. Therefore, all parts that get linked together must be compiler with sanitation. For what ever reason, the compiler complained that when running doc-tests some parts were not compiled with sanitation, although this was configured with `RUSTFLAGS` and there are no doc-tests in the first place. The fix was also configuring sanitation with `RUSTDOCFLAGS` and additionally ignoring ABI mismatch (which should no be an issue because this is only done for (non-existing) doc tests and even if they would exist this could only cause problems when running them, but not the lib itself).

The reason why this broke now is that using sanitizers requires nightly Rust. However, the nightly version was not pinned in CI and therefore now with a newer nightly Rust this broke.

Therefore, the nightly Rust version in CI is now pinned so that this will not randomly break again in the future.

While at it, the paths on which Rust CI is triggered have been fixed (they referenced `rust.yml` but the file is called `rust.yaml`) and the job `clippy` was renamed to `lint` which should make it more obvious what it is doing for non Rust users.