### PR TITLE
Fix building evmrs on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ tosca-cpp-coverage: tosca-cpp
 
 tosca-rust:
 	cd rust; \
-	cargo build --lib --release --features performance
+	cargo build --lib --release --features performance; \
+	# we expect the dynamic library to have .so suffix, so we copy it here if on macOS
+	# on other platforms the .dylib does not exists and the command fails, so we ignore errors
+	cp rust/target/release/libevmrs.dylib rust/target/release/libevmrs.so || true 
 
 tosca-rust-coverage:
 	cd rust; \

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,0 +1,7 @@
+[target.aarch64-apple-darwin]
+# allow dynamic lookup of symbols
+rustflags = ["-C", "link-arg=-Wl,-undefined,dynamic_lookup"]
+
+[target.x86_664-apple-darwin]
+# allow dynamic lookup of symbols
+rustflags = ["-C", "link-arg=-Wl,-undefined,dynamic_lookup"]


### PR DESCRIPTION
This PR fixes building evmrs on MAC OS.

The problem is that for what ever reason the MAC linker `ld64` does not use weak linkage even for symbols marked as weak.
e.g. `void __llvm_profile_set_filename(const char *filename) __attribute__((weak));`

Instead, it is necessary to explicitly pass arguments to the linker (`-undefined dynamic_lookup`).

Also, dynamic libraries have on MAC OS the `.dylib` extension, but it is expected that they are called `.so`.