### PR TITLE
Configure MSRV and fix new clippy lints

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 name = "evmrs"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.86"
 
 [profile.release]
 lto = true

--- a/rust/src/types/op_fn_data.rs
+++ b/rust/src/types/op_fn_data.rs
@@ -7,6 +7,13 @@ use crate::{
     u256,
 };
 
+// All function pointers stored here are pointers to functions implementing opcodes and come from
+// the same jumptable. This means that for the same opcode we always get the same function pointer.
+// And since the pointers are the top entry point of the function implementing the opcode, two
+// different opcodes can not have the same function pointer because then they would do the same
+// thing. This means that comparing function pointers for equality is equivalent to comparing the
+// opcodes they implement for equality.
+#[allow(unpredictable_function_pointer_comparisons)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct OpFnData<const STEPPABLE: bool> {
     func: Option<OpFn<STEPPABLE>>,

--- a/rust/src/types/op_fn_data.rs
+++ b/rust/src/types/op_fn_data.rs
@@ -9,10 +9,10 @@ use crate::{
 
 // All function pointers stored here are pointers to functions implementing opcodes and come from
 // the same jumptable. This means that for the same opcode we always get the same function pointer.
-// And since the pointers are the top entry point of the function implementing the opcode, two
-// different opcodes can not have the same function pointer because then they would do the same
-// thing. This means that comparing function pointers for equality is equivalent to comparing the
-// opcodes they implement for equality.
+// Since the pointers are the top entry point of the function implementing the opcode, two different
+// opcodes cannot have the same function pointer because then they would do the same thing. This
+// means that comparing function pointers for equality is equivalent to comparing the opcodes they
+// implement for equality.
 #[allow(unpredictable_function_pointer_comparisons)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct OpFnData<const STEPPABLE: bool> {

--- a/rust/src/types/stack.rs
+++ b/rust/src/types/stack.rs
@@ -133,8 +133,8 @@ impl Stack {
     }
 
     pub fn pop_with_location<const N: usize>(
-        &mut self,
-    ) -> Result<(PushLocation, [u256; N]), FailStatus> {
+        &'_ mut self,
+    ) -> Result<(PushLocation<'_>, [u256; N]), FailStatus> {
         let () = const { NonZero::<N>::VALID };
 
         self.check_underflow(N)?;


### PR DESCRIPTION
This PR sets the minimum supported Rust version (MSRV) in `Cargo.toml` to `1.86`.
This does not change the MSRV, it just configures it so that if an older version of Rust is used, once gets a more helpful error message.

This PR also fixes clippy lints that have been introduced in newer Rust versions (up to `1.89`).

Those lints do not break CI because Rust is already pinned to `1.86` in CI.