### PR TITLE
CT: Add new and old contracts to test state generation

### DIFF
--- a/go/ct/gen/selfdestructed.go
+++ b/go/ct/gen/selfdestructed.go
@@ -11,10 +11,14 @@
 package gen
 
 import (
+	"strings"
+
 	"pgregory.net/rand"
 )
 
 type SelfDestructedGenerator struct {
+	mustBeNewContract       bool
+	mustNotBeNewContract    bool
 	mustBeSelfDestructed    bool
 	mustNotBeSelfDestructed bool
 }
@@ -25,6 +29,8 @@ func NewSelfDestructedGenerator() *SelfDestructedGenerator {
 
 func (g *SelfDestructedGenerator) Clone() *SelfDestructedGenerator {
 	return &SelfDestructedGenerator{
+		mustBeNewContract:       g.mustBeNewContract,
+		mustNotBeNewContract:    g.mustNotBeNewContract,
 		mustBeSelfDestructed:    g.mustBeSelfDestructed,
 		mustNotBeSelfDestructed: g.mustNotBeSelfDestructed,
 	}
@@ -37,6 +43,14 @@ func (g *SelfDestructedGenerator) Restore(other *SelfDestructedGenerator) {
 	*g = *other
 }
 
+func (g *SelfDestructedGenerator) MarkAsNewContract() {
+	g.mustBeNewContract = true
+}
+
+func (g *SelfDestructedGenerator) MarkAsNotNewContract() {
+	g.mustNotBeNewContract = true
+}
+
 func (g *SelfDestructedGenerator) MarkAsSelfDestructed() {
 	g.mustBeSelfDestructed = true
 }
@@ -46,29 +60,57 @@ func (g *SelfDestructedGenerator) MarkAsNotSelfDestructed() {
 }
 
 func (g *SelfDestructedGenerator) String() string {
-	if g.mustBeSelfDestructed && g.mustNotBeSelfDestructed {
+	if g.mustBeSelfDestructed && g.mustNotBeSelfDestructed ||
+		g.mustBeNewContract && g.mustNotBeNewContract {
 		return "{false}" // unsatisfiable
-	} else if !g.mustBeSelfDestructed && !g.mustNotBeSelfDestructed {
-		return "{true}" // everything is valid
-	} else if g.mustBeSelfDestructed && !g.mustNotBeSelfDestructed {
-		return "{mustBeSelfDestructed}"
 	}
-	return "{mustNotBeSelfDestructed}"
+	if !g.mustBeSelfDestructed && !g.mustNotBeSelfDestructed &&
+		!g.mustBeNewContract && !g.mustNotBeNewContract {
+		return "{true}" // everything is valid
+	}
+
+	var selfdestruct string
+	var newContract string
+	if g.mustBeSelfDestructed {
+		selfdestruct = "mustBeSelfDestructed"
+	} else if g.mustNotBeSelfDestructed {
+		selfdestruct = "mustNotBeSelfDestructed"
+	}
+	if g.mustBeNewContract {
+		newContract = "mustBeNewContract"
+	} else if g.mustNotBeNewContract {
+		newContract = "mustNotBeNewContract"
+	}
+
+	out := strings.Trim(strings.Join([]string{selfdestruct, newContract}, ", "), ", ")
+	return "{" + out + "}"
 }
 
-func (g *SelfDestructedGenerator) Generate(rnd *rand.Rand) (bool, error) {
-
+func (g *SelfDestructedGenerator) Generate(rnd *rand.Rand) (bool, bool, error) {
 	var hasSelfDestroyed bool
+
 	if !g.mustBeSelfDestructed && !g.mustNotBeSelfDestructed {
 		// random true/false
 		hasSelfDestroyed = rnd.Int()%2 == 0
 	} else if g.mustBeSelfDestructed && g.mustNotBeSelfDestructed {
-		return false, ErrUnsatisfiable
+		return false, false, ErrUnsatisfiable
 	} else if g.mustBeSelfDestructed && !g.mustNotBeSelfDestructed {
 		hasSelfDestroyed = true
 	} else {
 		hasSelfDestroyed = false
 	}
 
-	return hasSelfDestroyed, nil
+	var isNewContract bool
+	if !g.mustBeNewContract && !g.mustNotBeNewContract {
+		// random true/false
+		isNewContract = rnd.Int()%2 == 0
+	} else if g.mustBeNewContract && g.mustNotBeNewContract {
+		return false, false, ErrUnsatisfiable
+	} else if g.mustBeNewContract && !g.mustNotBeNewContract {
+		isNewContract = true
+	} else {
+		isNewContract = false
+	}
+
+	return hasSelfDestroyed, isNewContract, nil
 }

--- a/go/ct/gen/selfdestructed_test.go
+++ b/go/ct/gen/selfdestructed_test.go
@@ -20,7 +20,7 @@ import (
 func TestSelfDestructedGenerator_UnconstrainedGeneratorCanGenerate(t *testing.T) {
 	rnd := rand.New(0)
 	generator := NewSelfDestructedGenerator()
-	_, err := generator.Generate(rnd)
+	_, _, err := generator.Generate(rnd)
 	if err != nil {
 		t.Errorf("unexpected error during generation: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestSelfDestructedGenerator_SelfDestructedConstraintIsEnforced(t *testing.T
 		t.Run(name, func(t *testing.T) {
 			generator := NewSelfDestructedGenerator()
 			test.constraintEffet(generator)
-			hasSelfDestructed, err := generator.Generate(rnd)
+			hasSelfDestructed, _, err := generator.Generate(rnd)
 
 			if err != nil {
 				t.Errorf("Unexpected error during generation: %v", err)
@@ -54,40 +54,138 @@ func TestSelfDestructedGenerator_SelfDestructedConstraintIsEnforced(t *testing.T
 	}
 }
 
-func TestSelfDestructedGenerator_ConflictingSelfDestructedConstraintsAreDetected(t *testing.T) {
+func TestSelfDestructedGenerator_IsNewContractConstraintIsEnforced(t *testing.T) {
 	rnd := rand.New(0)
-	generator := NewSelfDestructedGenerator()
-	generator.MarkAsSelfDestructed()
-	generator.MarkAsNotSelfDestructed()
 
-	_, err := generator.Generate(rnd)
-	if !errors.Is(err, ErrUnsatisfiable) {
-		t.Errorf("Conflicting has-self-destructed constraints not detected")
+	tests := map[string]struct {
+		wantGenerated   bool
+		constraintEffet func(g *SelfDestructedGenerator)
+	}{
+		"newContract":    {true, func(g *SelfDestructedGenerator) { g.MarkAsNewContract() }},
+		"NotNewContract": {false, func(g *SelfDestructedGenerator) { g.MarkAsNotNewContract() }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			generator := NewSelfDestructedGenerator()
+			test.constraintEffet(generator)
+			_, isNewContract, err := generator.Generate(rnd)
+
+			if err != nil {
+				t.Errorf("Unexpected error during generation: %v", err)
+			}
+
+			if isNewContract != test.wantGenerated {
+				t.Errorf("unexpected is-new-contract value")
+			}
+		})
+	}
+}
+
+func TestSelfDestructedGenerator_ConflictingConstraintsAreDetected(t *testing.T) {
+	tests := map[string]func(g *SelfDestructedGenerator){
+		"self-destructed constraints": func(g *SelfDestructedGenerator) {
+			g.MarkAsSelfDestructed()
+			g.MarkAsNotSelfDestructed()
+		},
+		"new-contract constraints": func(g *SelfDestructedGenerator) {
+			g.MarkAsNewContract()
+			g.MarkAsNotNewContract()
+		},
+	}
+
+	for name, setup := range tests {
+		t.Run(name, func(t *testing.T) {
+			rnd := rand.New(0)
+			generator := NewSelfDestructedGenerator()
+			setup(generator)
+
+			_, _, err := generator.Generate(rnd)
+			if !errors.Is(err, ErrUnsatisfiable) {
+				t.Errorf("Conflicting constraints not detected")
+			}
+		})
 	}
 }
 
 func TestSelfDestructedGenerator_String(t *testing.T) {
-	tests := map[struct {
-		mustDestruct    bool
-		mustNotDestruct bool
-	}]string{
-		{true, true}:   "{false}",
-		{true, false}:  "{mustBeSelfDestructed}",
-		{false, true}:  "{mustNotBeSelfDestructed}",
-		{false, false}: "{true}",
+	tests := map[string]struct {
+		mustBeSelfDestructed    bool
+		mustNotBeSelfDestructed bool
+		mustBeNewContract       bool
+		mustNotBeNewContract    bool
+		want                    string
+	}{
+		"no constraints": {
+			want: "{true}",
+		},
+		"conflict selfdestructed": {
+			mustBeSelfDestructed:    true,
+			mustNotBeSelfDestructed: true,
+			want:                    "{false}",
+		},
+		"conflict new contract": {
+			mustBeNewContract:    true,
+			mustNotBeNewContract: true,
+			want:                 "{false}",
+		},
+		"must be self-destructed": {
+			mustBeSelfDestructed: true,
+			want:                 "{mustBeSelfDestructed}",
+		},
+		"must not be self-destructed": {
+			mustNotBeSelfDestructed: true,
+			want:                    "{mustNotBeSelfDestructed}",
+		},
+		"must be new contract": {
+			mustBeNewContract: true,
+			want:              "{mustBeNewContract}",
+		},
+		"must not be new contract": {
+			mustNotBeNewContract: true,
+			want:                 "{mustNotBeNewContract}",
+		},
+		"must be self-destructed and new contract": {
+			mustBeSelfDestructed: true,
+			mustBeNewContract:    true,
+			want:                 "{mustBeSelfDestructed, mustBeNewContract}",
+		},
+		"must not be self-destructed and not be new contract": {
+			mustNotBeSelfDestructed: true,
+			mustNotBeNewContract:    true,
+			want:                    "{mustNotBeSelfDestructed, mustNotBeNewContract}",
+		},
+		"must be self-destructed and not be new contract": {
+			mustBeSelfDestructed: true,
+			mustNotBeNewContract: true,
+			want:                 "{mustBeSelfDestructed, mustNotBeNewContract}",
+		},
+		"must not be self-destructed and be new contract": {
+			mustNotBeSelfDestructed: true,
+			mustBeNewContract:       true,
+			want:                    "{mustNotBeSelfDestructed, mustBeNewContract}",
+		},
 	}
-	for values, want := range tests {
-		generator := NewSelfDestructedGenerator()
-		if values.mustDestruct {
-			generator.MarkAsSelfDestructed()
-		}
-		if values.mustNotDestruct {
-			generator.MarkAsNotSelfDestructed()
-		}
-		str := generator.String()
-		if str != want {
-			t.Errorf("unexpected string: wanted %v, but got %v", want, str)
-		}
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			generator := NewSelfDestructedGenerator()
+			if values.mustBeSelfDestructed {
+				generator.MarkAsSelfDestructed()
+			}
+			if values.mustNotBeSelfDestructed {
+				generator.MarkAsNotSelfDestructed()
+			}
+			if values.mustBeNewContract {
+				generator.MarkAsNewContract()
+			}
+			if values.mustNotBeNewContract {
+				generator.MarkAsNotNewContract()
+			}
+			str := generator.String()
+			if str != values.want {
+				t.Errorf("unexpected string: wanted %v, but got %v", values.want, str)
+			}
+		})
 	}
 }
 
@@ -96,9 +194,12 @@ func TestSelfDestructedGenerator_Restore(t *testing.T) {
 	gen2 := NewSelfDestructedGenerator()
 	gen2.mustNotBeSelfDestructed = true
 	gen2.mustBeSelfDestructed = true
+	gen2.mustNotBeNewContract = true
+	gen2.mustBeNewContract = true
 
 	gen1.Restore(gen2)
-	if !gen1.mustNotBeSelfDestructed || !gen1.mustBeSelfDestructed {
+	if !gen1.mustNotBeSelfDestructed || !gen1.mustBeSelfDestructed ||
+		!gen1.mustNotBeNewContract || !gen1.mustBeNewContract {
 		t.Error("selfDestructedGenerator's restore is broken")
 	}
 }

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -293,6 +293,14 @@ func (g *StateGenerator) BindToColdAddress(key Variable) {
 	g.accountsGen.BindCold(key)
 }
 
+func (g *StateGenerator) MustBeNewContract() {
+	g.hasSelfDestructedGen.MarkAsNewContract()
+}
+
+func (g *StateGenerator) MustNotBeNewContract() {
+	g.hasSelfDestructedGen.MarkAsNotNewContract()
+}
+
 func (g *StateGenerator) MustBeSelfDestructed() {
 	g.hasSelfDestructedGen.MarkAsSelfDestructed()
 }
@@ -484,7 +492,7 @@ func (g *StateGenerator) generateWith(rnd *rand.Rand, assignment Assignment) (*s
 	resultLastCallReturnData := RandomBytes(rnd, st.MaxDataSize)
 
 	// Invoke SelfDestructedGenerator
-	resultHasSelfdestructed, err := g.hasSelfDestructedGen.Generate(rnd)
+	resultHasSelfdestructed, resultIsNewContract, err := g.hasSelfDestructedGen.Generate(rnd)
 	if err != nil {
 		return nil, err
 	}
@@ -560,6 +568,7 @@ func (g *StateGenerator) generateWith(rnd *rand.Rand, assignment Assignment) (*s
 	result.CallData = resultCallData
 	result.LastCallReturnData = resultLastCallReturnData
 	result.HasSelfDestructed = resultHasSelfdestructed
+	result.IsNewContract = resultIsNewContract
 	result.RecentBlockHashes = resultRecentBlockHashes
 
 	return result, nil

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -824,6 +824,72 @@ func restrictAccountWarmCold(bindKey BindableExpression[U256]) func(generator *g
 }
 
 ////////////////////////////////////////////////////////////
+// Is new contract
+
+type isNewContract struct {
+}
+
+func IsNewContract() Condition {
+	return &isNewContract{}
+}
+
+func (c *isNewContract) Check(s *st.State) (bool, error) {
+	return s.IsNewContract, nil
+}
+
+func (c *isNewContract) Restrict(generator *gen.StateGenerator) {
+	generator.MustBeNewContract()
+}
+
+func (c *isNewContract) GetTestValues() []TestValue {
+	property := Property(c.String())
+	domain := boolDomain{}
+	restrict := func(generator *gen.StateGenerator, isNewContract bool) {
+		if isNewContract {
+			generator.MustBeNewContract()
+		} else {
+			generator.MustNotBeNewContract()
+		}
+	}
+	return []TestValue{
+		NewTestValue(property, domain, true, restrict),
+		NewTestValue(property, domain, false, restrict),
+	}
+}
+
+func (c *isNewContract) String() string {
+	return "isNewContract()"
+
+}
+
+////////////////////////////////////////////////////////////
+// Is not new contract
+
+type isNotNewContract struct {
+}
+
+func IsNotNewContract() Condition {
+	return &isNotNewContract{}
+}
+
+func (c *isNotNewContract) Check(s *st.State) (bool, error) {
+	res, err := IsNewContract().Check(s)
+	return !res, err
+}
+
+func (c *isNotNewContract) Restrict(generator *gen.StateGenerator) {
+	generator.MustNotBeNewContract()
+}
+
+func (c *isNotNewContract) GetTestValues() []TestValue {
+	return IsNewContract().GetTestValues()
+}
+
+func (c *isNotNewContract) String() string {
+	return "isNotNewContract()"
+}
+
+////////////////////////////////////////////////////////////
 // Has Self-Destructed
 
 type hasSelfDestructed struct {

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1700,13 +1700,16 @@ func getAllRules() []Rule {
 			for _, beneficiaryAccountEmpty := range []bool{true, false} {
 				for _, beneficiaryAccountIsWarm := range []bool{true, false} {
 					for _, hasSelfDestructed := range []bool{true, false} {
-						rules = append(rules, makeSelfDestructRules(
-							revision,
-							originatorHasFunds,
-							hasSelfDestructed,
-							beneficiaryAccountEmpty,
-							beneficiaryAccountIsWarm,
-						)...)
+						for _, isNewContract := range []bool{true, false} {
+							rules = append(rules, makeSelfDestructRules(
+								revision,
+								originatorHasFunds,
+								hasSelfDestructed,
+								beneficiaryAccountEmpty,
+								beneficiaryAccountIsWarm,
+								isNewContract,
+							)...)
+						}
 					}
 				}
 			}
@@ -2215,6 +2218,7 @@ func makeSelfDestructRules(
 	originatorHasSelfDestructedBefore bool,
 	beneficiaryAccountIsEmpty bool,
 	beneficiaryAccountIsWarm bool,
+	isNewContract bool,
 ) []Rule {
 
 	name := "_" + revision.String()
@@ -2255,6 +2259,15 @@ func makeSelfDestructRules(
 		name += "_originator_has_not_self_destructed"
 	}
 
+	var isNewContractCondition Condition
+	if isNewContract {
+		isNewContractCondition = IsNewContract()
+		name += "_is_new_contract"
+	} else {
+		isNewContractCondition = IsNotNewContract()
+		name += "_is_not_new_contract"
+	}
+
 	instruction := instruction{
 		op:        vm.SELFDESTRUCT,
 		name:      name,
@@ -2267,6 +2280,7 @@ func makeSelfDestructRules(
 			hasSelfDestructedCondition,
 			beneficiaryIsEmpty,
 			beneficiaryWarm,
+			isNewContractCondition,
 		},
 		parameters: []Parameter{AddressParameter{}},
 		effect:     selfDestructEffect,
@@ -2318,14 +2332,17 @@ func selfDestructEffect(s *st.State) {
 	s.GasRefund += refund
 
 	// Keep a record of the self-destruct operation.
-	s.HasSelfDestructed = true
-	s.SelfDestructedJournal = append(
-		s.SelfDestructedJournal,
-		st.NewSelfDestructEntry(
-			originatorAccount,
-			beneficiaryAccount,
-		),
-	)
+
+	if s.Revision < tosca.R13_Cancun || s.IsNewContract {
+		s.HasSelfDestructed = true
+		s.SelfDestructedJournal = append(
+			s.SelfDestructedJournal,
+			st.NewSelfDestructEntry(
+				originatorAccount,
+				beneficiaryAccount,
+			),
+		)
+	}
 
 	// After the self-destruct, this contract ends.
 	s.Status = st.Stopped

--- a/go/ct/st/accounts.go
+++ b/go/ct/st/accounts.go
@@ -155,7 +155,7 @@ func (a *Accounts) Diff(b *Accounts) (res []string) {
 func (a *Accounts) String() string {
 	res := strings.Builder{}
 	write := func(pattern string, args ...any) {
-		res.WriteString(fmt.Sprintf(pattern, args...))
+		fmt.Fprintf(&res, pattern, args...)
 	}
 
 	order := func(a, b tosca.Address) bool {

--- a/go/ct/st/serialization.go
+++ b/go/ct/st/serialization.go
@@ -75,6 +75,7 @@ type stateSerializable struct {
 	LastCallReturnData    Bytes
 	ReturnData            Bytes
 	CallJournal           *CallJournal
+	IsNewContract         bool
 	HasSelfDestructed     bool
 	SelfDestructedJournal []serializableSelfDestructEntry
 	RecentBlockHashes     ImmutableHashArray
@@ -161,6 +162,7 @@ func newStateSerializableFromState(state *State) *stateSerializable {
 		LastCallReturnData:    state.LastCallReturnData,
 		ReturnData:            state.ReturnData,
 		CallJournal:           state.CallJournal,
+		IsNewContract:         state.IsNewContract,
 		HasSelfDestructed:     state.HasSelfDestructed,
 		SelfDestructedJournal: newSerializableJournal(state.SelfDestructedJournal),
 		RecentBlockHashes:     state.RecentBlockHashes,
@@ -252,6 +254,7 @@ func (s *stateSerializable) deserialize() *State {
 	if s.CallJournal != nil {
 		state.CallJournal = s.CallJournal.Clone()
 	}
+	state.IsNewContract = s.IsNewContract
 	state.HasSelfDestructed = s.HasSelfDestructed
 	if s.SelfDestructedJournal != nil {
 		for _, entry := range s.SelfDestructedJournal {

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -156,6 +156,7 @@ type State struct {
 	CallData              Bytes
 	LastCallReturnData    Bytes
 	ReturnData            Bytes
+	IsNewContract         bool
 	HasSelfDestructed     bool
 	SelfDestructedJournal []SelfDestructEntry
 	RecentBlockHashes     ImmutableHashArray
@@ -210,6 +211,7 @@ func (s *State) Clone() *State {
 	clone.CallData = s.CallData
 	clone.LastCallReturnData = s.LastCallReturnData
 	clone.ReturnData = s.ReturnData
+	clone.IsNewContract = s.IsNewContract
 	clone.HasSelfDestructed = s.HasSelfDestructed
 	clone.SelfDestructedJournal = slices.Clone(s.SelfDestructedJournal)
 	clone.RecentBlockHashes = s.RecentBlockHashes
@@ -246,6 +248,7 @@ func (s *State) Eq(other *State) bool {
 		s.TransientStorage.Eq(other.TransientStorage) &&
 		s.Accounts.Eq(other.Accounts) &&
 		s.Logs.Eq(other.Logs) &&
+		s.IsNewContract == other.IsNewContract &&
 		s.HasSelfDestructed == other.HasSelfDestructed &&
 		slices.Equal(s.SelfDestructedJournal, other.SelfDestructedJournal) &&
 		s.RecentBlockHashes.Equal(other.RecentBlockHashes) &&
@@ -381,6 +384,7 @@ func (s *State) String() string {
 		write("\tReturnData: %x\n", s.ReturnData)
 	}
 
+	write("\tIsNewContract: %v\n", s.IsNewContract)
 	write("\tHasSelfDestructed: %v\n", s.HasSelfDestructed)
 	write("\tSelfDestructedJournal: %v\n", s.SelfDestructedJournal)
 
@@ -478,6 +482,10 @@ func (s *State) Diff(o *State) []string {
 
 	if (s.Status == Stopped || s.Status == Reverted) && s.ReturnData != o.ReturnData {
 		res = append(res, fmt.Sprintf("Different return data: %x vs %x", s.ReturnData, o.ReturnData))
+	}
+
+	if s.IsNewContract != o.IsNewContract {
+		res = append(res, fmt.Sprintf("Different is-new-contract: %v vs %v ", s.IsNewContract, o.IsNewContract))
 	}
 
 	if s.HasSelfDestructed != o.HasSelfDestructed {

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -80,8 +80,10 @@ func (c *ctRunContext) AccountExists(addr tosca.Address) bool {
 	return c.state.Accounts.Exists(addr)
 }
 
-func (c *ctRunContext) IsNewContract(addr tosca.Address) bool {
-	return true // TODO: add support for newly created contracts
+// IsNewContract returns whether the current contract is new,
+// it is only called in SelfDestruct therefore it is only relevant for the current contract.
+func (c *ctRunContext) IsNewContract(tosca.Address) bool {
+	return c.state.IsNewContract
 }
 
 func (c *ctRunContext) GetStorage(addr tosca.Address, key tosca.Key) tosca.Word {
@@ -162,8 +164,9 @@ func (c *ctRunContext) SelfDestruct(address tosca.Address, beneficiary tosca.Add
 			return false
 		}
 		c.state.HasSelfDestructed = true
+		return true
 	}
-	return true
+	return false
 }
 
 func (c *ctRunContext) AccessAccount(addr tosca.Address) tosca.AccessStatus {

--- a/go/ct/utils/adapter_test.go
+++ b/go/ct/utils/adapter_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/0xsoniclabs/tosca/go/ct/st"
 	"github.com/0xsoniclabs/tosca/go/tosca"
 	"github.com/0xsoniclabs/tosca/go/tosca/vm"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -332,6 +333,57 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			want, got := property.get(params)
 			if !reflect.DeepEqual(want, got) {
 				t.Errorf("failed to verify property, wanted %v, got %v of type %v and %v", want, got, reflect.TypeOf(want), reflect.TypeOf(got))
+			}
+		})
+	}
+}
+
+func TestAdapter_SelfDestructIsOnlyCalledWhenDestroying(t *testing.T) {
+	tests := map[string]struct {
+		revision               tosca.Revision
+		newContract            bool
+		expectedSelfDestructed bool
+	}{
+		"pre-cancun old account": {
+			revision:               tosca.R12_Shanghai,
+			newContract:            false,
+			expectedSelfDestructed: true,
+		},
+		"pre-cancun new account": {
+			revision:               tosca.R12_Shanghai,
+			newContract:            true,
+			expectedSelfDestructed: true,
+		},
+		"cancun new account": {
+			revision:               tosca.R13_Cancun,
+			newContract:            true,
+			expectedSelfDestructed: true,
+		},
+		"cancun old account": {
+			revision:               tosca.R13_Cancun,
+			newContract:            false,
+			expectedSelfDestructed: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			state := st.State{
+				Revision:      test.revision,
+				IsNewContract: test.newContract,
+			}
+			c := ctRunContext{
+				state: &state,
+			}
+			address := tosca.Address{1, 2, 3}
+
+			selfdestructed := c.SelfDestruct(address, tosca.Address{4, 5, 6})
+			if test.expectedSelfDestructed {
+				require.True(t, selfdestructed)
+				require.True(t, state.HasSelfDestructed)
+			} else {
+				require.False(t, selfdestructed)
+				require.False(t, state.HasSelfDestructed)
 			}
 		})
 	}

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -258,7 +258,6 @@ func TestRunContextAdapter_GetAndSetTransientStorage(t *testing.T) {
 
 func TestRunContextAdapter_SelfDestructReportsWhetherTheAccountHasAlreadyBeenSelfDestructed(t *testing.T) {
 	cancunTime := uint64(42)
-	londonBlock := big.NewInt(42)
 	tests := map[string]struct {
 		blockTime      uint64
 		selfdestructed bool
@@ -290,12 +289,12 @@ func TestRunContextAdapter_SelfDestructReportsWhetherTheAccountHasAlreadyBeenSel
 			beneficiary := common.Address{0x43}
 
 			blockContext := geth.BlockContext{
-				BlockNumber: londonBlock.Add(londonBlock, big.NewInt(1)),
+				BlockNumber: big.NewInt(43),
 				Time:        test.blockTime,
 			}
 			chainConfig := &params.ChainConfig{
 				CancunTime:  &cancunTime,
-				LondonBlock: londonBlock,
+				LondonBlock: big.NewInt(42),
 				ChainID:     big.NewInt(42),
 			}
 			evm := geth.NewEVM(blockContext,


### PR DESCRIPTION
This PR models new and old contracts in the test state generation of the CT. This ensures that test cases with contracts marked as new and not marked as new are produced. 