### PR TITLE
Fix selfdestruct balance update

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -488,6 +488,8 @@ func (a *runContextAdapter) GetLogs() []tosca.Log {
 	return nil
 }
 
+// SelfDestruct implements the selfdestruct operation and performs the necessary balance updates according to geth:
+// https://github.com/ethereum/go-ethereum/blob/58557cb4635d4e6f3e49fcdc82a6469554e929a6/core/vm/instructions.go#L882-L954
 func (a *runContextAdapter) SelfDestruct(addr tosca.Address, beneficiary tosca.Address) bool {
 	stateDb := a.evm.StateDB
 

--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -490,18 +490,30 @@ func (a *runContextAdapter) GetLogs() []tosca.Log {
 
 func (a *runContextAdapter) SelfDestruct(addr tosca.Address, beneficiary tosca.Address) bool {
 	stateDb := a.evm.StateDB
+
 	// HasSelfDestructed only returns true if it is the first call to SelfDestruct
 	selfdestructed := !stateDb.HasSelfDestructed(common.Address(addr))
 
+	isCancun := a.evm.ChainConfig().IsCancun(a.evm.Context.BlockNumber, a.evm.Context.Time)
+	isNewContract := stateDb.IsNewContract(common.Address(addr))
+	isSelfTransfer := beneficiary == addr
+
 	// Transfer balance to beneficiary
 	balance := stateDb.GetBalance(common.Address(addr))
-	stateDb.SubBalance(common.Address(addr), balance, tracing.BalanceDecreaseSelfdestruct)
-	stateDb.AddBalance(common.Address(beneficiary), balance, tracing.BalanceIncreaseSelfdestruct)
 
 	// Contracts are only destructed before Cancun or if they are marked as new
-	if !a.evm.ChainConfig().IsCancun(a.evm.Context.BlockNumber, a.evm.Context.Time) ||
-		stateDb.IsNewContract(common.Address(addr)) {
+	if !isCancun || isNewContract {
+		if !isSelfTransfer {
+			stateDb.AddBalance(common.Address(beneficiary), balance, tracing.BalanceIncreaseSelfdestruct)
+		}
+		stateDb.SubBalance(common.Address(addr), balance, tracing.BalanceDecreaseSelfdestruct)
 		stateDb.SelfDestruct(common.Address(addr))
+	}
+
+	// If the contract already exists only transfer if the beneficiary is not self
+	if isCancun && !isNewContract && !isSelfTransfer {
+		stateDb.SubBalance(common.Address(addr), balance, tracing.BalanceDecreaseSelfdestruct)
+		stateDb.AddBalance(common.Address(beneficiary), balance, tracing.BalanceIncreaseSelfdestruct)
 	}
 
 	return selfdestructed

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -459,6 +459,8 @@ func TestRunContextAdapter_SelfdestructBalanceUpdateAllCombinations(t *testing.T
 						LondonBlock: big.NewInt(42),
 						ChainID:     big.NewInt(42),
 					}
+					require.Equal(t, isCancun, chainConfig.IsCancun(blockContext.BlockNumber, blockContext.Time))
+
 					evm := geth.NewEVM(blockContext,
 						stateDb,
 						chainConfig,

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -388,6 +388,92 @@ func TestRunContextAdapter_SelfdestructDependsOnIsNewContract(t *testing.T) {
 	}
 }
 
+func TestRunContextAdapter_SelfdestructBalanceUpdateAllCombinations(t *testing.T) {
+	boolToInt := func(b bool) int {
+		if b {
+			return 1
+		}
+		return 0
+	}
+
+	for _, isCancun := range []bool{false, true} {
+		for _, isNewContract := range []bool{false, true} {
+			for _, isSelfTransfer := range []bool{false, true} {
+				name := fmt.Sprintf("isCancun=%t_isNewContract=%t_isSelfTransfer=%t", isCancun, isNewContract, isSelfTransfer)
+				t.Run(name, func(t *testing.T) {
+					ctrl := gomock.NewController(t)
+					stateDb := NewMockStateDb(ctrl)
+
+					// Balance updates according to geth:
+					// https://github.com/ethereum/go-ethereum/blob/58557cb4635d4e6f3e49fcdc82a6469554e929a6/core/vm/instructions.go#L882-L954
+					//
+					// B+ ... balance is added to beneficiary
+					// B- ... balance is subtracted from address
+					// SD ... SelfDestruct is called on address
+					//
+					// | isCancun | isNewContract | isSelfTransfer | B+ | B- | SD |
+					// |----------|---------------|----------------|----|----|----|
+					// | false    | false         | false          | 1  | 1  | 1  |
+					// | false    | false         | true           | 0  | 1  | 1  |
+					// | false    | true          | false          | 1  | 1  | 1  |
+					// | false    | true          | true           | 0  | 1  | 1  |
+					// | true     | false         | false          | 1  | 1  | 0  |
+					// | true     | false         | true           | 0  | 0  | 0  |
+					// | true     | true          | false          | 1  | 1  | 1  |
+					// | true     | true          | true           | 0  | 1  | 1  |
+
+					expectAddBalance := !isSelfTransfer
+					expectSubBalance := !isCancun || isNewContract || !isSelfTransfer
+					expectSelfDestruct := !isCancun || isNewContract
+
+					address := common.Address{0x42}
+					beneficiary := common.Address{0x43}
+					if isSelfTransfer {
+						beneficiary = address
+					}
+
+					// Account has not already been selfdestructed
+					stateDb.EXPECT().HasSelfDestructed(address).Return(false)
+
+					stateDb.EXPECT().GetBalance(address).Return(uint256.NewInt(24))
+					stateDb.EXPECT().IsNewContract(address).Return(isNewContract).AnyTimes()
+					stateDb.EXPECT().AddBalance(common.Address(beneficiary), uint256.NewInt(24),
+						tracing.BalanceIncreaseSelfdestruct).Times(boolToInt(expectAddBalance))
+					stateDb.EXPECT().SubBalance(common.Address(address), uint256.NewInt(24),
+						tracing.BalanceDecreaseSelfdestruct).Times(boolToInt(expectSubBalance))
+					stateDb.EXPECT().SelfDestruct(address).Times(boolToInt(expectSelfDestruct))
+
+					blockContext := geth.BlockContext{
+						BlockNumber: big.NewInt(43),
+						Time:        42,
+					}
+					chainConfig := &params.ChainConfig{
+						CancunTime: func() *uint64 {
+							if isCancun {
+								t := uint64(42)
+								return &t
+							} else {
+								return nil
+							}
+						}(),
+						LondonBlock: big.NewInt(42),
+						ChainID:     big.NewInt(42),
+					}
+					evm := geth.NewEVM(blockContext,
+						stateDb,
+						chainConfig,
+						geth.Config{},
+					)
+					adapter := &runContextAdapter{evm: evm, caller: address}
+					destructed := adapter.SelfDestruct(tosca.Address(address), tosca.Address(beneficiary))
+					require.True(t, destructed,
+						"Selfdestruct should return true as the account has not been selfdestructed before")
+				})
+			}
+		}
+	}
+}
+
 func TestRunContextAdapter_SnapshotHandling(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	stateDb := NewMockStateDb(ctrl)


### PR DESCRIPTION
This PR fixes the balance update inside the selfdestruct implementation of the geth adapter.
This fixes the breaking eest [run](https://scala.fantom.network/job/Aida/job/Experimental/job/Aida-exec-spec-tests/29/) using tosca interpreters and geth state db. The geth state db does not perform any balance updates if selfdestruct is called multiple times.