### PR TITLE
Add missing isNewContract unit test

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -43,14 +43,14 @@ threshold:
 # override rules should be listed in order from specific to more general rules.
 override:
   # files
+  - threshold: 100
+    path: go/geth_adapter/adapter.go
   - threshold: 0
     path: go/ct/spc/specification.go
   - threshold: 0
     path: go/ct/st/transient_storage.go
   - threshold: 0
     path: go/ct/utils/adapter.go
-  - threshold: 0
-    path: go/geth_adapter/adapter.go
   - threshold: 0
     path: go/integration_test/processor/scenario.go
   - threshold: 0
@@ -69,6 +69,10 @@ override:
     path: go/tosca/utils.go
 
   # packages
+  - threshold:  100
+    path: go/interpreter/lfvm
+  - threshold:  100
+    path: go/interpreter/sfvm
   - threshold: 0
     path: go/ct/spc
   - threshold: 0
@@ -87,8 +91,6 @@ override:
     path: go/integration_test/processor
   - threshold: 0
     path: go/interpreter/evmc
-  - threshold:  100
-    path: go/interpreter/lfvm
   - threshold: 0
     path: go/processor/floria
   - threshold: 0

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -732,6 +732,24 @@ func TestRunContextAdapter_BooleanChecksReturnCorrectValues(t *testing.T) {
 				return adapter.HasSelfDestructed(tosca.Address{0x42})
 			},
 		},
+		"isNewContract-true": {
+			primingMock: func(stateDb *MockStateDb) {
+				stateDb.EXPECT().IsNewContract(common.Address{0x42}).Return(true)
+			},
+			want: true,
+			functionCall: func(adapter *runContextAdapter) bool {
+				return adapter.IsNewContract(tosca.Address{0x42})
+			},
+		},
+		"isNewContract-false": {
+			primingMock: func(stateDb *MockStateDb) {
+				stateDb.EXPECT().IsNewContract(common.Address{0x42}).Return(false)
+			},
+			want: false,
+			functionCall: func(adapter *runContextAdapter) bool {
+				return adapter.IsNewContract(tosca.Address{0x42})
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
The geth adapter is in production and should have 100% unit test coverage. This PR adds the missing unit test and updates the `.testcoverage.yml`.